### PR TITLE
fix: snippets not loading from folder correctly

### DIFF
--- a/src/snippets/snippet_helper_functions.ts
+++ b/src/snippets/snippet_helper_functions.ts
@@ -136,7 +136,7 @@ export async function getSnippetsWithinFolder(folder: TFolder) {
 
         }
         else {
-            const newSnippets = await this.getSnippetsWithinFolder(fileOrFolder as TFolder);
+            const newSnippets = await getSnippetsWithinFolder(fileOrFolder as TFolder);
             snippets.push(...newSnippets);
         }
     }


### PR DESCRIPTION
In the current version `this.getSnippetsWithinFolder` does not exist, because you refactored it into a different file with no class this function belongs to.

After removing the `this` everything works as expected