### PR TITLE
fix mac command+Z undo sometimes not work as expected

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "obsidian-latex-suite",
-	"version": "1.5.2",
+	"version": "1.6.8",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "obsidian-latex-suite",
-			"version": "1.5.2",
+			"version": "1.6.8",
 			"license": "MIT",
 			"devDependencies": {
 				"@codemirror/autocomplete": "^6.0.0",

--- a/src/main.ts
+++ b/src/main.ts
@@ -305,7 +305,7 @@ export default class LatexSuitePlugin extends Plugin {
 
 
 	private readonly onKeydown = (event: KeyboardEvent, view: EditorView) => {
-		const success = this.handleKeydown(event.key, event.shiftKey, event.ctrlKey, view);
+		const success = this.handleKeydown(event.key, event.shiftKey, event.ctrlKey||event.metaKey, view);
 
 		if (success) event.preventDefault();
 	}


### PR DESCRIPTION
Fix #93 
In Macos, command+z not always work for latex suite snippets expansion.

For example, under default snippets, input `pi` will auto expand to `\pi`. However, command+z won't undo the expansion. It add a `z` after cursor instead. 

In function `handleKeydown = (key: string, shiftKey: boolean, ctrlKey: boolean, view: EditorView)`, you use ctrlKey to Allows Ctrl + z for undo, instead of triggering a snippet ending with z. In mac, it's `command+z` instead of `ctrl+z` trigger undo operation. And the command key corresponds to KeyboardEvent.metaKey.