### PR TITLE
feat: add snippet setting

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -537,7 +537,7 @@ export default class LatexSuitePlugin extends Plugin {
 
 
 			// When in inline math, remove any spaces at the end of the replacement
-			if (withinMath) {
+			if (withinMath && this.settings.removeSnippetWhitespace) {
 				let spaceIndex = 0;
 				if (replacement.endsWith(" ")) {
 					spaceIndex = -1;

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -16,6 +16,7 @@ import { debouncedSetSnippetsFromFileOrFolder } from "./snippets/snippet_helper_
 export interface LatexSuiteSettings {
     snippets: string;
     snippetsEnabled: boolean;
+    removeSnippetWhitespace: boolean;
     loadSnippetsFromFile: boolean;
     snippetsFileLocation: string;
     autofractionEnabled: boolean;
@@ -36,6 +37,7 @@ export interface LatexSuiteSettings {
 export const DEFAULT_SETTINGS: LatexSuiteSettings = {
     snippets: DEFAULT_SNIPPETS,
     snippetsEnabled: true,
+    removeSnippetWhitespace: true,
     loadSnippetsFromFile: false,
     snippetsFileLocation: "",
     concealEnabled: false,
@@ -92,7 +94,15 @@ export class LatexSuiteSettingTab extends PluginSettingTab {
                     await this.plugin.saveSettings();
                 }));
 
-
+        new Setting(containerEl)
+            .setName("Inline math: remove whitespaces")
+            .setDesc("Whether to remove trailing whitespaces when expanding snippets at the end of inline math blocks.")
+            .addToggle(toggle => toggle
+                .setValue(this.plugin.settings.removeSnippetWhitespace)
+                .onChange(async (value) => {
+                    this.plugin.settings.removeSnippetWhitespace = value;
+                    await this.plugin.saveSettings();
+                }));
 
 		const snippetsSetting = new Setting(containerEl)
             .setName("Snippets")


### PR DESCRIPTION
Adds an additional setting for the user to choose whether they want the snippet whitespaces at the end of an inline math block removed