### PR TITLE
feat: add setting to change autofraction symbol

### DIFF
--- a/src/features/autofraction.ts
+++ b/src/features/autofraction.ts
@@ -104,8 +104,7 @@ export const runAutoFractionCursor = (view: EditorView, range: SelectionRange, p
         numerator = numerator.slice(1, -1);
     }
 
-
-    const replacement = "\\frac{" + numerator + "}{$0}$1";
+	const replacement = `${plugin.settings.autofractionSymbol}{${numerator}}{$0}$1`
 
     queueSnippet(view, {from: start, to: to, insert: replacement, keyPressed: "/"});
 

--- a/src/features/autofraction.ts
+++ b/src/features/autofraction.ts
@@ -104,7 +104,7 @@ export const runAutoFractionCursor = (view: EditorView, range: SelectionRange, p
         numerator = numerator.slice(1, -1);
     }
 
-	const replacement = `${plugin.settings.autofractionSymbol}{${numerator}}{$0}$1`
+    const replacement = `${plugin.settings.autofractionSymbol}{${numerator}}{$0}$1`
 
     queueSnippet(view, {from: start, to: to, insert: replacement, keyPressed: "/"});
 

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -25,7 +25,7 @@ export interface LatexSuiteSettings {
     colorPairedBracketsEnabled: boolean;
     highlightCursorBracketsEnabled: boolean;
     mathPreviewEnabled: boolean;
-	autofractionSymbol: string,
+    autofractionSymbol: string,
     autofractionExcludedEnvs: string,
     autofractionBreakingChars: string;
     matrixShortcutsEnabled: boolean;
@@ -48,7 +48,7 @@ export const DEFAULT_SETTINGS: LatexSuiteSettings = {
     highlightCursorBracketsEnabled: true,
     mathPreviewEnabled: true,
     autofractionEnabled: true,
-	autofractionSymbol: "\\frac",
+    autofractionSymbol: "\\frac",
     autofractionExcludedEnvs:
     `[
         ["^{", "}"],
@@ -65,14 +65,14 @@ export const DEFAULT_SETTINGS: LatexSuiteSettings = {
 
 
 export class LatexSuiteSettingTab extends PluginSettingTab {
-	plugin: LatexSuitePlugin;
+    plugin: LatexSuitePlugin;
     snippetsEditor: EditorView;
     snippetsFileLocEl: HTMLElement;
 
-	constructor(app: App, plugin: LatexSuitePlugin) {
-		super(app, plugin);
-		this.plugin = plugin;
-	}
+    constructor(app: App, plugin: LatexSuitePlugin) {
+        super(app, plugin);
+        this.plugin = plugin;
+    }
 
 
     hide() {
@@ -80,10 +80,10 @@ export class LatexSuiteSettingTab extends PluginSettingTab {
     }
 
 
-	display(): void {
-		const {containerEl} = this;
+    display(): void {
+        const {containerEl} = this;
 
-		containerEl.empty();
+        containerEl.empty();
 
         containerEl.createEl("div", {text: "Snippets"}).addClasses(["setting-item", "setting-item-heading", "setting-item-name"]);
 
@@ -99,7 +99,7 @@ export class LatexSuiteSettingTab extends PluginSettingTab {
                 }));
 
 
-		const snippetsSetting = new Setting(containerEl)
+        const snippetsSetting = new Setting(containerEl)
             .setName("Snippets")
             .setDesc("Enter snippets here.  Remember to add a comma after each snippet, and escape all backslashes with an extra \\. Lines starting with \"//\" will be treated as comments and ignored.")
             .setClass("snippets-text-area");
@@ -396,7 +396,7 @@ export class LatexSuiteSettingTab extends PluginSettingTab {
                     await this.plugin.saveSettings();
                 }));
 
-		new Setting(containerEl)
+        new Setting(containerEl)
             .setName("Fraction symbol")
             .setDesc("The fraction symbol to use in the replacement. e.g. \\frac, \\dfrac, \\tfrac")
             .addText(text => text
@@ -413,15 +413,15 @@ export class LatexSuiteSettingTab extends PluginSettingTab {
             .setName("Excluded environments")
             .setDesc("A list of environments to exclude auto-fraction from running in. For example, to exclude auto-fraction from running while inside an exponent, such as e^{...}, use  [\"^{\", \"}\"]")
             .addTextArea(text => text
-				.setPlaceholder("[ [\"^{\", \"}] ]")
-				.setValue(this.plugin.settings.autofractionExcludedEnvs)
-				.onChange(async (value) => {
+                .setPlaceholder("[ [\"^{\", \"}] ]")
+                .setValue(this.plugin.settings.autofractionExcludedEnvs)
+                .onChange(async (value) => {
 
                     this.plugin.setAutofractionExcludedEnvs(value);
 
-					this.plugin.settings.autofractionExcludedEnvs = value;
-					await this.plugin.saveSettings();
-				}));
+                    this.plugin.settings.autofractionExcludedEnvs = value;
+                    await this.plugin.saveSettings();
+                }));
 
 
         new Setting(containerEl)
@@ -527,7 +527,7 @@ export class LatexSuiteSettingTab extends PluginSettingTab {
                     this.plugin.settings.removeSnippetWhitespace = value;
                     await this.plugin.saveSettings();
                 }));
-	}
+    }
 }
 
 

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -25,6 +25,7 @@ export interface LatexSuiteSettings {
     colorPairedBracketsEnabled: boolean;
     highlightCursorBracketsEnabled: boolean;
     mathPreviewEnabled: boolean;
+	autofractionSymbol: string,
     autofractionExcludedEnvs: string,
     autofractionBreakingChars: string;
     matrixShortcutsEnabled: boolean;
@@ -47,6 +48,7 @@ export const DEFAULT_SETTINGS: LatexSuiteSettings = {
     highlightCursorBracketsEnabled: true,
     mathPreviewEnabled: true,
     autofractionEnabled: true,
+	autofractionSymbol: "\\frac",
     autofractionExcludedEnvs:
     `[
         ["^{", "}"],
@@ -391,6 +393,18 @@ export class LatexSuiteSettingTab extends PluginSettingTab {
                 .setValue(this.plugin.settings.autofractionEnabled)
                 .onChange(async (value) => {
                     this.plugin.settings.autofractionEnabled = value;
+                    await this.plugin.saveSettings();
+                }));
+
+		new Setting(containerEl)
+            .setName("Fraction symbol")
+            .setDesc("The fraction symbol to use in the replacement. e.g. \\frac, \\dfrac, \\tfrac")
+            .addText(text => text
+                .setPlaceholder(DEFAULT_SETTINGS.autofractionSymbol)
+                .setValue(this.plugin.settings.autofractionSymbol)
+                .onChange(async (value) => {
+                    this.plugin.settings.autofractionSymbol = value;
+
                     await this.plugin.saveSettings();
                 }));
 


### PR DESCRIPTION
Closes #98 

Added a textArea setting that allows the user to change what symbol is inserted during autofraction replacement.