### PR TITLE
fix(autofraction): only remove outer parentheses when they are matching

### DIFF
--- a/src/features/autofraction.ts
+++ b/src/features/autofraction.ts
@@ -94,17 +94,22 @@ export const runAutoFractionCursor = (view: EditorView, ctx: Context, range: Sel
 		}
 	}
 
-	// Run autofraction
-	let numerator = view.state.sliceDoc(start, to);
-
 	// Don't run on an empty line
-	if (numerator === "") return false;
+	if (start === to) { return false; }
 
+	// Remove unnecessary outer parentheses
+	const { beg, end } = (() => {
+		if (curLine.charAt(start) === "(" && curLine.charAt(to - 1) === ")") {
+			const closing = findMatchingBracket(curLine, start, "(", ")", false, to);
+			if (closing === to - 1) {
+				return { beg: start + 1, end: to - 1 };
+			}
+		}
+		return { beg: start, end: to };
+	})();
 
-	// Remove brackets
-	if (curLine.charAt(start) === "(" && curLine.charAt(to - 1) === ")") {
-		numerator = numerator.slice(1, -1);
-	}
+	// Run autofraction
+	const numerator = view.state.sliceDoc(beg, end);
 
 	const replacement = `${settings.autofractionSymbol}{${numerator}}{$0}$1`
 

--- a/src/features/autofraction.ts
+++ b/src/features/autofraction.ts
@@ -97,19 +97,13 @@ export const runAutoFractionCursor = (view: EditorView, ctx: Context, range: Sel
 	// Don't run on an empty line
 	if (start === to) { return false; }
 
-	// Remove unnecessary outer parentheses
-	const { beg, end } = (() => {
-		if (curLine.charAt(start) === "(" && curLine.charAt(to - 1) === ")") {
-			const closing = findMatchingBracket(curLine, start, "(", ")", false, to);
-			if (closing === to - 1) {
-				return { beg: start + 1, end: to - 1 };
-			}
-		}
-		return { beg: start, end: to };
-	})();
-
 	// Run autofraction
-	const numerator = view.state.sliceDoc(beg, end);
+	let numerator = view.state.sliceDoc(start, to);
+	
+	// Remove unnecessary outer parentheses
+	if (numerator.at(0) === "(" && numerator.at(-1) === ")") {
+			numerator = numerator.slice(1, -1);
+	}
 
 	const replacement = `${settings.autofractionSymbol}{${numerator}}{$0}$1`
 

--- a/src/features/autofraction.ts
+++ b/src/features/autofraction.ts
@@ -102,7 +102,10 @@ export const runAutoFractionCursor = (view: EditorView, ctx: Context, range: Sel
 	
 	// Remove unnecessary outer parentheses
 	if (numerator.at(0) === "(" && numerator.at(-1) === ")") {
+		const closing = findMatchingBracket(numerator, 0, "(", ")", false);
+		if (closing === numerator.length - 1) {
 			numerator = numerator.slice(1, -1);
+		}
 	}
 
 	const replacement = `${settings.autofractionSymbol}{${numerator}}{$0}$1`


### PR DESCRIPTION
resolves #206

![output](https://github.com/artisticat1/obsidian-latex-suite/assets/38791932/bdc71d73-1fec-4c38-803b-8e5ff76f0330)
