### PR TITLE
add "\lceil: \rceil" and "\lfloor: \rfloor" to auto enlarge brackets

### DIFF
--- a/src/features/auto_enlarge_brackets.ts
+++ b/src/features/auto_enlarge_brackets.ts
@@ -23,7 +23,7 @@ export const autoEnlargeBrackets = (view: EditorView) => {
 
 	for (let i = start; i < end; i++) {
 
-		const brackets:{[open: string]: string} = {"(": ")", "[": "]", "\\{": "\\}", "\\langle": "\\rangle", "\\lvert": "\\rvert"};
+		const brackets:{[open: string]: string} = {"(": ")", "[": "]", "\\{": "\\}", "\\langle": "\\rangle", "\\lvert": "\\rvert", "\\lceil": "\\rceil", "\\lfloor": "\\rfloor"};
 		const openBrackets = Object.keys(brackets);
 		let found = false;
 		let open = "";


### PR DESCRIPTION
i also thought about adding a snippet similar to the `"norm"` snippet for both of them, but while `"floor"` as a trigger would work, `"ceil"` would clash with the chemistry `"ce"` snippet, so i didn't. if you want i can add them later.

