### PR TITLE
Modified tabstop replacement to allow for arbitrary length stop numbers in placeholder tabstops

### DIFF
--- a/src/snippets/codemirror/snippet_change_spec.ts
+++ b/src/snippets/codemirror/snippet_change_spec.ts
@@ -39,7 +39,7 @@ export class SnippetChangeSpec {
                 if (!(text.charAt(i+1) === "{")) continue;
     
                 // Find the index of the matching closing bracket
-                const closingIndex = text.indexOf("}", i)
+                const closingIndex = findMatchingBracket(text, i+1, "{", "}", false, start + this.insert.length);
                 
                 // Create a copy of the entire tabstop string from the document
                 const tabstopString = text.slice(i, closingIndex+1)

--- a/src/snippets/codemirror/snippet_change_spec.ts
+++ b/src/snippets/codemirror/snippet_change_spec.ts
@@ -42,13 +42,13 @@ export class SnippetChangeSpec {
                 const closingIndex = findMatchingBracket(text, i+1, "{", "}", false, start + this.insert.length);
                 
                 // Create a copy of the entire tabstop string from the document
-                const tabstopString = text.slice(i, closingIndex+1)
+                const tabstopString = text.slice(i, closingIndex+1);
     
                 // If there is not a colon in the tabstop string, it is incorrectly formatted
                 if (!tabstopString.includes(":")) continue;
     
                 // Get the first index of a colon, which we will use as our number/replacement split point
-                const colonIndex = tabstopString.indexOf(":")
+                const colonIndex = tabstopString.indexOf(":");
     
                 // Parse the number from the tabstop string, which is all characters after the {
                 // and before the colon index
@@ -66,7 +66,7 @@ export class SnippetChangeSpec {
     
             // Replace the tabstop indicator "$X" with ""
             const tabstop = {number: number, from: tabstopStart, to: tabstopEnd, replacement: tabstopReplacement};
-            tabstops.push(tabstop)
+            tabstops.push(tabstop);
         }
 
         return tabstops;

--- a/src/snippets/codemirror/snippet_change_spec.ts
+++ b/src/snippets/codemirror/snippet_change_spec.ts
@@ -20,7 +20,7 @@ export class SnippetChangeSpec {
         const tabstops:TabstopSpec[] = [];
         const text = view.state.doc.toString();
 
-        for (let i = 0; i < text.length; i++) {
+        for (let i = start; i < start + this.insert.length; i++) {
 
             if (!(text.charAt(i) === "$")) {
                 continue;

--- a/src/snippets/tabstop.ts
+++ b/src/snippets/tabstop.ts
@@ -124,7 +124,7 @@ export function tabstopSpecsToTabstopGroups(tabstops: TabstopSpec[], color: numb
 
     const result = [];
     const numbers = Object.keys(tabstopsByNumber);
-    numbers.sort();
+    numbers.sort((a,b) => parseInt(a) - parseInt(b));
 
     for (const number of numbers) {
         const grp = new TabstopGroup(tabstopsByNumber[number], color);


### PR DESCRIPTION
This is an implementation of a recent feature request to allow for more than 9 tabstops in snippet replacements. I have modified the implementation of placeholder tabstops to allow for arbitrary length stop numbers by splitting the inside of the placeholder by the first colon. I have tested the modified `getTabstops` function locally and it seems to be behaving properly, but I expect further testing might be in order to make sure the modifications don't get in the way of efficiency or have any extreme edge cases.