### PR TITLE
Add an option to disable snippet expansion when IME is on

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "obsidian-latex-suite",
-	"version": "1.9.1",
+	"version": "1.9.2",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "obsidian-latex-suite",
-			"version": "1.9.1",
+			"version": "1.9.2",
 			"license": "MIT",
 			"dependencies": {
 				"set.prototype.difference": "^1.1.5",

--- a/src/latex_suite.ts
+++ b/src/latex_suite.ts
@@ -20,6 +20,7 @@ import { concealPlugin } from "./editor_extensions/conceal";
 import { LatexSuiteCMSettings } from "./settings/settings";
 import { colorPairedBracketsPluginLowestPrec, highlightCursorBracketsPlugin } from "./editor_extensions/highlight_brackets";
 import { cursorTooltipBaseTheme, cursorTooltipField } from "./editor_extensions/math_tooltip";
+import { isComposing } from "./utils/editor_utils";
 
 export const handleUpdate = (update: ViewUpdate) => {
 	const cursorTriggeredByChange = update.state.field(cursorTriggerStateField, false);
@@ -37,13 +38,7 @@ export const handleUpdate = (update: ViewUpdate) => {
 }
 
 export const onKeydown = (event: KeyboardEvent, view: EditorView) => {
-	// Check if the user is typing in an IME composition.
-	// view.composing and event.isComposing are false for the first keydown event of an IME composition,
-	// so we need to check for event.keyCode === 229 to prevent IME from triggering keydown events.
-	// Note that keyCode is deprecated - it is used here because it is apparently the only way to detect the first keydown event of an IME composition.
-	const isIME = view.composing || event.keyCode === 229;
-	
-	const success = handleKeydown(event.key, event.shiftKey, event.ctrlKey || event.metaKey, isIME, view);
+	const success = handleKeydown(event.key, event.shiftKey, event.ctrlKey || event.metaKey, isComposing(view, event), view);
 
 	if (success) event.preventDefault();
 }

--- a/src/latex_suite.ts
+++ b/src/latex_suite.ts
@@ -37,6 +37,13 @@ export const handleUpdate = (update: ViewUpdate) => {
 }
 
 export const onKeydown = (event: KeyboardEvent, view: EditorView) => {
+	// Prevent IME from triggering keydown events.
+	// view.composing and event.isComposing are false for the first keydown event of an IME composition,
+	// so we need to check for event.keyCode === 229 to prevent IME from triggering keydown events.
+	// Note that keyCode is deprecated - it is used here because it is apparently the only way to detect the first keydown event of an IME composition.
+	const isIME = view.composing || event.keyCode === 229;
+	if (isIME) return;
+
 	const success = handleKeydown(event.key, event.shiftKey, event.ctrlKey || event.metaKey, view);
 
 	if (success) event.preventDefault();

--- a/src/latex_suite.ts
+++ b/src/latex_suite.ts
@@ -37,19 +37,18 @@ export const handleUpdate = (update: ViewUpdate) => {
 }
 
 export const onKeydown = (event: KeyboardEvent, view: EditorView) => {
-	// Prevent IME from triggering keydown events.
+	// Check if the user is typing in an IME composition.
 	// view.composing and event.isComposing are false for the first keydown event of an IME composition,
 	// so we need to check for event.keyCode === 229 to prevent IME from triggering keydown events.
 	// Note that keyCode is deprecated - it is used here because it is apparently the only way to detect the first keydown event of an IME composition.
 	const isIME = view.composing || event.keyCode === 229;
-	if (isIME) return;
 
-	const success = handleKeydown(event.key, event.shiftKey, event.ctrlKey || event.metaKey, view);
+	const success = handleKeydown(event.key, event.shiftKey, event.ctrlKey || event.metaKey, isIME, view);
 
 	if (success) event.preventDefault();
 }
 
-export const handleKeydown = (key: string, shiftKey: boolean, ctrlKey: boolean, view: EditorView) => {
+export const handleKeydown = (key: string, shiftKey: boolean, ctrlKey: boolean, isIME: boolean, view: EditorView) => {
 
 	const settings = getLatexSuiteConfig(view);
 	const ctx = Context.fromView(view);
@@ -58,6 +57,9 @@ export const handleKeydown = (key: string, shiftKey: boolean, ctrlKey: boolean, 
 
 	if (settings.snippetsEnabled) {
 
+		// Prevent IME from triggering keydown events.
+		if (settings.suppressSnippetTriggerOnIME && isIME) return;
+	
 		// Allows Ctrl + z for undo, instead of triggering a snippet ending with z
 		if (!ctrlKey) {
 			try {

--- a/src/latex_suite.ts
+++ b/src/latex_suite.ts
@@ -42,7 +42,7 @@ export const onKeydown = (event: KeyboardEvent, view: EditorView) => {
 	// so we need to check for event.keyCode === 229 to prevent IME from triggering keydown events.
 	// Note that keyCode is deprecated - it is used here because it is apparently the only way to detect the first keydown event of an IME composition.
 	const isIME = view.composing || event.keyCode === 229;
-
+	
 	const success = handleKeydown(event.key, event.shiftKey, event.ctrlKey || event.metaKey, isIME, view);
 
 	if (success) event.preventDefault();

--- a/src/settings/settings.ts
+++ b/src/settings/settings.ts
@@ -6,6 +6,7 @@ import { DEFAULT_SNIPPET_VARIABLES } from "src/utils/default_snippet_variables";
 interface LatexSuiteBasicSettings {
 	snippetsEnabled: boolean;
 	snippetsTrigger: "Tab" | " "
+	suppressSnippetTriggerOnIME: boolean;
 	removeSnippetWhitespace: boolean;
 	loadSnippetsFromFile: boolean;
 	loadSnippetVariablesFromFile: boolean;
@@ -52,6 +53,7 @@ export const DEFAULT_SETTINGS: LatexSuitePluginSettings = {
 	// Basic settings
 	snippetsEnabled: true,
 	snippetsTrigger: "Tab",
+	suppressSnippetTriggerOnIME: true,
 	removeSnippetWhitespace: true,
 	loadSnippetsFromFile: false,
 	loadSnippetVariablesFromFile: false,

--- a/src/settings/settings_tab.ts
+++ b/src/settings/settings_tab.ts
@@ -127,6 +127,18 @@ export class LatexSuiteSettingTab extends PluginSettingTab {
 				})
 			);
 
+		
+		new Setting(containerEl)
+			.setName("Don't trigger snippets when IME is active")
+			.setDesc("Whether to suppress the snippet triggering when an IME is active.")
+			.addToggle((toggle) => toggle
+				.setValue(this.plugin.settings.suppressSnippetTriggerOnIME)
+				.onChange(async (value) => {
+					this.plugin.settings.suppressSnippetTriggerOnIME = value;
+					await this.plugin.saveSettings();
+				})
+		);
+
 
 		this.addHeading(containerEl, "Conceal", "math-integral-x");
 

--- a/src/settings/settings_tab.ts
+++ b/src/settings/settings_tab.ts
@@ -127,18 +127,6 @@ export class LatexSuiteSettingTab extends PluginSettingTab {
 				})
 			);
 
-		
-		new Setting(containerEl)
-			.setName("Don't trigger snippets when IME is active")
-			.setDesc("Whether to suppress the snippet triggering when an IME is active.")
-			.addToggle((toggle) => toggle
-				.setValue(this.plugin.settings.suppressSnippetTriggerOnIME)
-				.onChange(async (value) => {
-					this.plugin.settings.suppressSnippetTriggerOnIME = value;
-					await this.plugin.saveSettings();
-				})
-		);
-
 
 		this.addHeading(containerEl, "Conceal", "math-integral-x");
 
@@ -421,6 +409,17 @@ export class LatexSuiteSettingTab extends PluginSettingTab {
 				this.plugin.settings.removeSnippetWhitespace = value;
 				await this.plugin.saveSettings();
 			}));
+
+		new Setting(containerEl)
+			.setName("Don't trigger snippets when IME is active")
+			.setDesc("Whether to suppress the snippet triggering when an IME is active.")
+			.addToggle((toggle) => toggle
+				.setValue(this.plugin.settings.suppressSnippetTriggerOnIME)
+				.onChange(async (value) => {
+					this.plugin.settings.suppressSnippetTriggerOnIME = value;
+					await this.plugin.saveSettings();
+				})
+			);
 
 		new Setting(containerEl)
 		.setName("Code languages to interpret as math mode")

--- a/src/utils/editor_utils.ts
+++ b/src/utils/editor_utils.ts
@@ -134,3 +134,15 @@ export function escalateToToken(cursor: TreeCursor, dir: Direction, target: stri
 
 	return null;
 }
+
+
+/**
+ * Check if the user is typing in an IME composition.
+ * Returns true even if the given event is the first keydown event of an IME composition.
+ */
+export function isComposing(view: EditorView, event: KeyboardEvent): boolean {
+	// view.composing and event.isComposing are false for the first keydown event of an IME composition,
+	// so we need to check for event.keyCode === 229 to prevent IME from triggering keydown events.
+	// Note that keyCode is deprecated - it is used here because it is apparently the only way to detect the first keydown event of an IME composition.
+	return view.composing || event.keyCode === 229;
+}


### PR DESCRIPTION
Resolves #284 

I have tested it on macOS and iPadOS, Japanese IME only.
If you have any suggestions, please feel free to let me know.

https://github.com/artisticat1/obsidian-latex-suite/assets/72342591/38634f4e-93bd-4f6e-9232-d1cd2561406a