### PR TITLE
Update default_snippets.js

### DIFF
--- a/src/default_snippets.js
+++ b/src/default_snippets.js
@@ -269,7 +269,7 @@
 
 
     // Misc
-
+    {trigger: "exm", replacement: "> **Example:** $0\n> $1", options: "tA"},
     // Automatically convert standalone letters in text to math (except a, A, I).
     // (Un-comment to enable)
     // {trigger: /([^'])\b([B-HJ-Zb-z])\b([\n\s.,?!:'])/, replacement: "[[0]]$[[1]]$[[2]]", options: "tA"},


### PR DESCRIPTION
Auto expands "exm" into

```
> **Example:** $0
> $1
```

Extremely nice to have. Gilles (the creator of these snippets) posts screenshots of himself using example blocks in his latex documents, although he never added any snippets for it which is quite weird.