### PR TITLE
Allows for matrix commands in inline math

### DIFF
--- a/src/features/matrix_shortcuts.ts
+++ b/src/features/matrix_shortcuts.ts
@@ -20,7 +20,7 @@ export const runMatrixShortcuts = (view: EditorView, ctx: Context, key: string, 
 	if (!isInsideAnEnv) return false;
 
 
-	if (key === "Tab") {
+	if (key === "Tab" && !shiftKey) {
 		view.dispatch(view.state.replaceSelection(" & "));
 
 		return true;
@@ -34,6 +34,9 @@ export const runMatrixShortcuts = (view: EditorView, ctx: Context, key: string, 
 			const nextLine = d.line(nextLineNo);
 
 			setCursor(view, nextLine.to);
+		}
+		else if (ctx.mode.inlineMath) {
+			view.dispatch(view.state.replaceSelection(" \\\\ "));
 		}
 		else {
 			view.dispatch(view.state.replaceSelection(" \\\\\n"));

--- a/src/features/run_snippets.ts
+++ b/src/features/run_snippets.ts
@@ -124,6 +124,11 @@ const isOnWordBoundary = (state: EditorState, triggerPos: number, to: number, wo
 }
 
 const trimWhitespace = (replacement: string, ctx: Context) => {
+	// Modify matrix expansion for inline math
+	const regex = new RegExp("\\n\\$0\\n", "g");
+  	replacement = replacement.replace(regex, " $0 "); 
+
+	// Trim whitespace
 	let spaceIndex = 0;
 
 	if (replacement.endsWith(" ")) {

--- a/src/latex_suite.ts
+++ b/src/latex_suite.ts
@@ -109,7 +109,7 @@ export const handleKeydown = (key: string, shiftKey: boolean, ctrlKey: boolean, 
 		}
 	}
 
-	if (settings.matrixShortcutsEnabled && ctx.mode.blockMath) {
+	if (settings.matrixShortcutsEnabled && ctx.mode.strictlyInMath()) {
 		if (["Tab", "Enter"].contains(key)) {
 			success = runMatrixShortcuts(view, ctx, key, shiftKey);
 


### PR DESCRIPTION
Resolves #262.

Removes the newlines from the matrix snippet expansion while in inline mode, and allows the tab/enter keys insert & or \\  to even if you're inline. Under the new behavior, shift-tab will bring the cursor to the next tabstop, and shift-enter will move the cursor to the next line. 

Demo:
https://github.com/artisticat1/obsidian-latex-suite/assets/64773493/130d8ad9-e9ff-4104-a589-a6af14ee8f2a