### PR TITLE
Some improvements to plugin initialization

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "obsidian-latex-suite",
-	"version": "1.9.2",
+	"version": "1.9.4",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "obsidian-latex-suite",
-			"version": "1.9.2",
+			"version": "1.9.4",
 			"license": "MIT",
 			"dependencies": {
 				"set.prototype.difference": "^1.1.5",
@@ -1086,12 +1086,13 @@
 			}
 		},
 		"node_modules/braces": {
-			"version": "3.0.2",
-			"resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
-			"integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+			"integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
-				"fill-range": "^7.0.1"
+				"fill-range": "^7.1.1"
 			},
 			"engines": {
 				"node": ">=8"
@@ -1806,10 +1807,11 @@
 			}
 		},
 		"node_modules/fill-range": {
-			"version": "7.0.1",
-			"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
-			"integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+			"version": "7.1.1",
+			"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+			"integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"to-regex-range": "^5.0.1"
 			},
@@ -2312,6 +2314,7 @@
 			"resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
 			"integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
 			"dev": true,
+			"license": "MIT",
 			"engines": {
 				"node": ">=0.12.0"
 			}
@@ -3165,6 +3168,7 @@
 			"resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
 			"integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"is-number": "^7.0.0"
 			},
@@ -4059,12 +4063,12 @@
 			}
 		},
 		"braces": {
-			"version": "3.0.2",
-			"resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
-			"integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+			"integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
 			"dev": true,
 			"requires": {
-				"fill-range": "^7.0.1"
+				"fill-range": "^7.1.1"
 			}
 		},
 		"builtin-modules": {
@@ -4613,9 +4617,9 @@
 			}
 		},
 		"fill-range": {
-			"version": "7.0.1",
-			"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
-			"integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+			"version": "7.1.1",
+			"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+			"integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
 			"dev": true,
 			"requires": {
 				"to-regex-range": "^5.0.1"

--- a/src/latex_suite.ts
+++ b/src/latex_suite.ts
@@ -1,5 +1,4 @@
-import { Prec, Extension } from "@codemirror/state";
-import { EditorView, ViewUpdate, tooltips } from "@codemirror/view";
+import { EditorView, ViewUpdate } from "@codemirror/view";
 
 import { runSnippets } from "./features/run_snippets";
 import { runAutoFraction } from "./features/autofraction";
@@ -10,16 +9,11 @@ import { Context } from "./utils/context";
 import { getCharacterAtPos, replaceRange } from "./utils/editor_utils";
 import { setSelectionToNextTabstop } from "./snippets/snippet_management";
 import { removeAllTabstops } from "./snippets/codemirror/tabstops_state_field";
-import { getLatexSuiteConfigExtension, getLatexSuiteConfig } from "./snippets/codemirror/config";
+import { getLatexSuiteConfig } from "./snippets/codemirror/config";
 import { clearSnippetQueue } from "./snippets/codemirror/snippet_queue_state_field";
 import { handleUndoRedo } from "./snippets/codemirror/history";
-import { snippetExtensions } from "./snippets/codemirror/extensions";
 
-import { concealPlugin } from "./editor_extensions/conceal";
-
-import { LatexSuiteCMSettings } from "./settings/settings";
-import { colorPairedBracketsPluginLowestPrec, highlightCursorBracketsPlugin } from "./editor_extensions/highlight_brackets";
-import { cursorTooltipBaseTheme, cursorTooltipField, handleMathTooltip } from "./editor_extensions/math_tooltip";
+import { handleMathTooltip } from "./editor_extensions/math_tooltip";
 import { isComposing } from "./utils/editor_utils";
 
 export const handleUpdate = (update: ViewUpdate) => {
@@ -112,20 +106,4 @@ export const handleKeydown = (key: string, shiftKey: boolean, ctrlKey: boolean, 
 	}
 
 	return false;
-}
-
-// CodeMirror extensions that are required for Latex Suite to run
-export const latexSuiteExtensions = (settings: LatexSuiteCMSettings) => [
-	getLatexSuiteConfigExtension(settings),
-	Prec.highest(EditorView.domEventHandlers({"keydown": onKeydown})), // Register keymaps
-	EditorView.updateListener.of(handleUpdate),
-	snippetExtensions
-];
-
-// Optional CodeMirror extensions for optional features
-export const optionalExtensions: {[feature: string]: Extension[]} = {
-	"conceal": [concealPlugin.extension],
-	"colorPairedBrackets": [colorPairedBracketsPluginLowestPrec],
-	"highlightCursorBrackets": [highlightCursorBracketsPlugin.extension],
-	"mathPreview": [cursorTooltipField.extension, cursorTooltipBaseTheme, tooltips({position: "absolute"})]
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -10,7 +10,6 @@ import { iterateCM6 } from "./utils/editor_utils";
 import { reconfigureLatexSuiteConfig } from "./snippets/codemirror/config";
 import { SnippetVariables, parseSnippetVariables, parseSnippets } from "./snippets/parse";
 import { latexSuiteExtensions, optionalExtensions } from "./latex_suite";
-import { sortSnippets } from "./snippets/sort";
 
 export default class LatexSuitePlugin extends Plugin {
 	settings: LatexSuitePluginSettings;
@@ -35,9 +34,7 @@ export default class LatexSuitePlugin extends Plugin {
 		this.addEditorCommands();
 	}
 
-	onunload() {
-
-	}
+	onunload() {}
 
 	legacyEditorWarning() {
 		// @ts-ignore
@@ -80,7 +77,7 @@ export default class LatexSuitePlugin extends Plugin {
 			const tempSnippetVariables = await this.getSettingsSnippetVariables();
 			const tempSnippets = await this.getSettingsSnippets(tempSnippetVariables);
 
-			this.CMSettings = processLatexSuiteSettings(sortSnippets(tempSnippets), this.settings);
+			this.CMSettings = processLatexSuiteSettings(tempSnippets, this.settings);
 
 			// Use onLayoutReady so that we don't try to read the snippets file too early
 			this.app.workspace.onLayoutReady(() => {
@@ -141,7 +138,7 @@ export default class LatexSuitePlugin extends Plugin {
 
 		this.showSnippetsLoadedNotice(snippets.length, Object.keys(snippetVariables).length,  becauseFileLocationUpdated, becauseFileUpdated);
 
-		return sortSnippets(snippets);
+		return snippets;
 	}
 
 	async processSettings(becauseFileLocationUpdated = false, becauseFileUpdated = false) {

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,4 +1,4 @@
-import { Extension } from "@codemirror/state";
+import { Extension, Prec } from "@codemirror/state";
 import { Plugin, Notice, loadMathJax, addIcon } from "obsidian";
 import { onFileCreate, onFileChange, onFileDelete, getSnippetsFromFiles, getFileSets, getVariablesFromFiles, tryGetVariablesFromUnknownFiles } from "./settings/file_watch";
 import { LatexSuitePluginSettings, DEFAULT_SETTINGS, LatexSuiteCMSettings, processLatexSuiteSettings } from "./settings/settings";
@@ -7,14 +7,19 @@ import { ICONS } from "./settings/ui/icons";
 
 import { getEditorCommands } from "./features/editor_commands";
 import { iterateCM6 } from "./utils/editor_utils";
-import { reconfigureLatexSuiteConfig } from "./snippets/codemirror/config";
+import { getLatexSuiteConfigExtension, reconfigureLatexSuiteConfig } from "./snippets/codemirror/config";
 import { SnippetVariables, parseSnippetVariables, parseSnippets } from "./snippets/parse";
-import { latexSuiteExtensions, optionalExtensions } from "./latex_suite";
+import { handleUpdate, onKeydown } from "./latex_suite";
+import { EditorView, tooltips } from "@codemirror/view";
+import { snippetExtensions } from "./snippets/codemirror/extensions";
+import { concealPlugin } from "./editor_extensions/conceal";
+import { colorPairedBracketsPluginLowestPrec, highlightCursorBracketsPlugin } from "./editor_extensions/highlight_brackets";
+import { cursorTooltipBaseTheme, cursorTooltipField } from "./editor_extensions/math_tooltip";
 
 export default class LatexSuitePlugin extends Plugin {
 	settings: LatexSuitePluginSettings;
 	CMSettings: LatexSuiteCMSettings;
-	editorExtensions:Extension[] = [];
+	editorExtensions: Extension[] = [];
 
 	async onload() {
 		await this.loadSettings();
@@ -144,7 +149,9 @@ export default class LatexSuitePlugin extends Plugin {
 	async processSettings(becauseFileLocationUpdated = false, becauseFileUpdated = false) {
 		this.CMSettings = processLatexSuiteSettings(await this.getSnippets(becauseFileLocationUpdated, becauseFileUpdated), this.settings);
 		this.reconfigureLatexSuiteConfig();
-		this.refreshCMExtensions();
+		this.setEditorExtensions();
+		// Request Obsidian to reconfigure CM extensions
+		this.app.workspace.updateOptions();
 	}
 
 	reconfigureLatexSuiteConfig() {
@@ -155,24 +162,34 @@ export default class LatexSuitePlugin extends Plugin {
 		})
 	}
 
-	refreshCMExtensions() {
+	// Set 'this.editorExtensions' based on the contents of 'this.CMSettings'
+	setEditorExtensions() {
 		// Remove all currently loaded CM extensions
+		// In order for 'this.app.workspace.updateOptions()' to function as
+		// expected, you cannot assign a new array to 'this.editorExtensions'.
 		while (this.editorExtensions.length) this.editorExtensions.pop();
 
-		// Load Latex Suite extensions
-		this.editorExtensions.push(latexSuiteExtensions(this.CMSettings));
+		// Compulsory extensions
+		this.editorExtensions.push([
+			getLatexSuiteConfigExtension(this.CMSettings),
+			Prec.highest(EditorView.domEventHandlers({ "keydown": onKeydown })),
+			EditorView.updateListener.of(handleUpdate),
+			snippetExtensions,
+		]);
 
-		// Load optional CM extensions according to plugin settings
-		const extensionDict = optionalExtensions;
-		const features = Object.keys(optionalExtensions);
-
-		for (const feature of features) {
-			// @ts-ignore
-			if (this.CMSettings[feature + "Enabled"]) {
-				this.editorExtensions.push(extensionDict[feature]);
-			}
-		}
-		this.app.workspace.updateOptions();
+		// Optional extensions
+		if (this.CMSettings.concealEnabled)
+			this.editorExtensions.push(concealPlugin.extension);
+		if (this.CMSettings.colorPairedBracketsEnabled)
+			this.editorExtensions.push(colorPairedBracketsPluginLowestPrec);
+		if (this.CMSettings.highlightCursorBracketsEnabled)
+			this.editorExtensions.push(highlightCursorBracketsPlugin.extension);
+		if (this.CMSettings.mathPreviewEnabled)
+			this.editorExtensions.push([
+				cursorTooltipField.extension,
+				cursorTooltipBaseTheme,
+				tooltips({ position: "absolute" }),
+			]);
 	}
 
 	showSnippetsLoadedNotice(nSnippets: number, nSnippetVariables: number, becauseFileLocationUpdated: boolean, becauseFileUpdated: boolean) {

--- a/src/main.ts
+++ b/src/main.ts
@@ -6,8 +6,7 @@ import { LatexSuiteSettingTab } from "./settings/settings_tab";
 import { ICONS } from "./settings/ui/icons";
 
 import { getEditorCommands } from "./features/editor_commands";
-import { iterateCM6 } from "./utils/editor_utils";
-import { getLatexSuiteConfigExtension, reconfigureLatexSuiteConfig } from "./snippets/codemirror/config";
+import { getLatexSuiteConfigExtension } from "./snippets/codemirror/config";
 import { SnippetVariables, parseSnippetVariables, parseSnippets } from "./snippets/parse";
 import { handleUpdate, onKeydown } from "./latex_suite";
 import { EditorView, tooltips } from "@codemirror/view";
@@ -148,18 +147,9 @@ export default class LatexSuitePlugin extends Plugin {
 
 	async processSettings(becauseFileLocationUpdated = false, becauseFileUpdated = false) {
 		this.CMSettings = processLatexSuiteSettings(await this.getSnippets(becauseFileLocationUpdated, becauseFileUpdated), this.settings);
-		this.reconfigureLatexSuiteConfig();
 		this.setEditorExtensions();
 		// Request Obsidian to reconfigure CM extensions
 		this.app.workspace.updateOptions();
-	}
-
-	reconfigureLatexSuiteConfig() {
-		iterateCM6(this.app.workspace, (view) => {
-			view.dispatch({
-				effects: reconfigureLatexSuiteConfig(this.CMSettings)
-			});
-		})
 	}
 
 	// Set 'this.editorExtensions' based on the contents of 'this.CMSettings'

--- a/src/settings/file_watch.ts
+++ b/src/settings/file_watch.ts
@@ -6,6 +6,7 @@ import { parseSnippets, parseSnippetVariables, type SnippetVariables } from "../
 import differenceImplementation from "set.prototype.difference";
 // @ts-ignore
 import intersectionImplementation from "set.prototype.intersection";
+import { sortSnippets } from "src/snippets/sort";
 
 const difference: <T>(self: Set<T>, other: Set<T>) => Set<T> = differenceImplementation;
 const intersection: <T>(self: Set<T>, other: Set<T>) => Set<T> = intersectionImplementation;
@@ -170,5 +171,5 @@ export async function getSnippetsFromFiles(
 		}
 	}
 
-	return snippets;
+	return sortSnippets(snippets);
 }

--- a/src/snippets/codemirror/config.ts
+++ b/src/snippets/codemirror/config.ts
@@ -1,5 +1,5 @@
 import { EditorView } from "@codemirror/view";
-import { Facet, Compartment, EditorState } from "@codemirror/state";
+import { Facet, EditorState } from "@codemirror/state";
 import { LatexSuiteCMSettings, processLatexSuiteSettings, DEFAULT_SETTINGS } from "src/settings/settings";
 
 export const latexSuiteConfig = Facet.define<LatexSuiteCMSettings, LatexSuiteCMSettings>({
@@ -15,12 +15,6 @@ export function getLatexSuiteConfig(viewOrState: EditorView | EditorState) {
     return state.facet(latexSuiteConfig);
 }
 
-export const latexSuiteConfigCompartment = new Compartment();
-
 export function getLatexSuiteConfigExtension(pluginSettings: LatexSuiteCMSettings) {
-    return latexSuiteConfigCompartment.of(latexSuiteConfig.of(pluginSettings));
-}
-
-export function reconfigureLatexSuiteConfig(pluginSettings: LatexSuiteCMSettings) {
-    return latexSuiteConfigCompartment.reconfigure(latexSuiteConfig.of(pluginSettings));
+    return latexSuiteConfig.of(pluginSettings);
 }

--- a/src/utils/editor_utils.ts
+++ b/src/utils/editor_utils.ts
@@ -1,4 +1,4 @@
-import { Platform, Workspace, MarkdownView } from "obsidian";
+import { Platform } from "obsidian";
 import { EditorView } from "@codemirror/view";
 import { SyntaxNode, TreeCursor } from "@lezer/common";
 import { EditorState } from "@codemirror/state";
@@ -7,14 +7,6 @@ export function replaceRange(view: EditorView, start: number, end: number, repla
 	view.dispatch({
 		changes: {from: start, to: end, insert: replacement}
 	});
-}
-
-export function iterateCM6(workspace: Workspace, callback: (editor: EditorView) => unknown) {
-    workspace.iterateAllLeaves(leaf => {
-        leaf?.view instanceof MarkdownView &&
-        (leaf.view.editor as any)?.cm instanceof EditorView &&
-        callback((leaf.view.editor as any).cm);
-    });
 }
 
 export function getCharacterAtPos(viewOrState: EditorView | EditorState, pos: number) {


### PR DESCRIPTION
### Changes
* Fixed vulnerability in dependencies by running `npm audit fix`.
* Removed redundant `sortSnippets` calls in "main.ts". Snippets returned by the function `parseSnippets` are already sorted.
* Refactored the function `refreshCMExtensions` and renamed it to `setEditorExtensions`.
  * Moved the line calling `this.app.workspace.updateOptions` outside of the function so that its side effect is limited to modifying `this.editorExtensions`.
  * Eliminated the use of `latexSuiteExtensions` and `optionalExtensions`. The previous code feels hacky because it required `@ts-ignore`. In addition, I found the name `latexSuiteExtensions` unclear.
* Removed the call to `reconfigureLatexSuiteConfig` in `processSettings`. The extensions reconfigured by `reconfigureLatexSuiteConfig` will be removed in the call to `refreshCMExtensions` (`setEditorExtensions` in new code), so `reconfigureLatexSuiteConfig` is unnecessary.