### PR TITLE
Improve performance of `runSnippetCursor`

### DIFF
--- a/src/features/run_snippets.ts
+++ b/src/features/run_snippets.ts
@@ -34,9 +34,10 @@ const runSnippetCursor = (view: EditorView, ctx: Context, key: string, range: Se
 	const settings = getLatexSuiteConfig(view);
 	const {from, to} = range;
 	const sel = view.state.sliceDoc(from, to);
-
+	const line = view.state.sliceDoc(0, to);
+	const updatedLine = line + key;
 	for (const snippet of settings.snippets) {
-		let effectiveLine = view.state.sliceDoc(0, to);
+		let effectiveLine = line;
 
 		if (!snippetShouldRunInMode(snippet.options, ctx.mode)) {
 			continue;
@@ -45,8 +46,7 @@ const runSnippetCursor = (view: EditorView, ctx: Context, key: string, range: Se
 		if (snippet.options.automatic || snippet.type === "visual") {
 			// If the key pressed wasn't a text character, continue
 			if (!(key.length === 1)) continue;
-
-			effectiveLine += key;
+			effectiveLine = updatedLine;
 		}
 		else if (!(key === settings.snippetsTrigger)) {
 			// The snippet must be triggered by a key


### PR DESCRIPTION
Optimizes `runSnippetCursor` in `run_snippet.ts` by reducing redundant calls to `view.state.sliceDoc`.
Partially solves #320 by improving the editting of large files.

# Performance Testing

Tested with a large markdown file generated with the following command:
```bash
python -c "print('aa\n'*4000)" > test.md
```
Pushed a key when the cursor is at the bottom of the file and measured the time spent handling the keydown event using DevTools.

Test Environment:
- OS: Microsoft Windows 11 Home
- CPU: Intel(R) Core(TM) i7-8750H CPU
- RAM: 16GB

Results:
- Before the update: Handling a single keydown event took approximately 50ms, with `runSnippetCursor` consuming 47ms.
- After the update: Handling a single keydown event took approximately 3ms, with `runSnippetCursor` consuming 0.2ms.