### PR TITLE
Add gather to default env names for matrix shortcuts

### DIFF
--- a/src/settings/settings.ts
+++ b/src/settings/settings.ts
@@ -82,7 +82,7 @@ export const DEFAULT_SETTINGS: LatexSuitePluginSettings = {
 		["^{", "}"],
 		["\\\\pu{", "}"]
 	]`,
-	matrixShortcutsEnvNames: "pmatrix, cases, align, bmatrix, Bmatrix, vmatrix, Vmatrix, array, matrix",
+	matrixShortcutsEnvNames: "pmatrix, cases, align, gather, bmatrix, Bmatrix, vmatrix, Vmatrix, array, matrix",
 	autoEnlargeBracketsTriggers: "sum, int, frac, prod, bigcup, bigcap",
 	forceMathLanguages: "math",
 }


### PR DESCRIPTION
I was confused why the matrix shortcuts commands weren't working in the gather environment. It turns out, gather just wasn't in the default list for environments to enable to shortcuts. 