### PR TITLE
Conceal all types of fractions, not just \frac

### DIFF
--- a/src/editor_extensions/conceal_fns.ts
+++ b/src/editor_extensions/conceal_fns.ts
@@ -375,7 +375,7 @@ function concealSet(eqn: string): ConcealSpec[] {
 function concealFraction(eqn: string): ConcealSpec[] {
 	const concealSpecs: ConcealSpec[] = [];
 
-	for (const match of eqn.matchAll(/\\(frac){/g)) {
+	for (const match of eqn.matchAll(/\\(frac|dfrac|tfrac|gfrac){/g)) {
 		// index of the closing bracket of the numerator
 		const numeratorEnd = findMatchingBracket(eqn, match.index, "{", "}", false);
 		if (numeratorEnd === -1) continue;


### PR DESCRIPTION
Currently, the only fractions that are concealed are `\frac`. I prefer using `\dfrac` for everything, since it'll always display as large, even when doing inline math. However, doing this has made me lose out on concealed fractions.This PR aims to fix that. Now, the regex for finding fractions looks for all types of fractions. 

Regex is absolutely not my strong suit, and I wouldn't be surprised if there's a better way to match for the string "frac" that *may* or may not be preceded by `d`, `t`, or `g`. Feel free to enlighten me on this!