### PR TITLE
Conceal \operatorname

### DIFF
--- a/src/editor_extensions/conceal_fns.ts
+++ b/src/editor_extensions/conceal_fns.ts
@@ -410,22 +410,22 @@ function concealFraction(eqn: string): ConcealSpec[] {
 }
 
 function concealOperatorname(eqn) {
-  const regexStr = "\\\\operatorname{([A-Za-z]+)}";
-  const regex = new RegExp(regexStr, "g");
-  const matches = [...eqn.matchAll(regex)];
-  const specs = [];
-  for (const match of matches) {
-    const value = match[1];
-    const start2 = match.index;
-    const end2 = start2 + match[0].length;
-    specs.push(mkConcealSpec({
-      start: start2,
-      end: end2,
-      text: value,
-      class: "cm-concealed-mathrm cm-variable-2"
-    }));
-  }
-  return specs;
+	const regexStr = "\\\\operatorname{([A-Za-z]+)}";
+	const regex = new RegExp(regexStr, "g");
+	const matches = [...eqn.matchAll(regex)];
+	const specs = [];
+	for (const match of matches) {
+		const value = match[1];
+		const start2 = match.index;
+		const end2 = start2 + match[0].length;
+		specs.push(mkConcealSpec({
+			start: start2,
+			end: end2,
+			text: value,
+			class: "cm-concealed-mathrm cm-variable-2"
+		}));
+	}
+	return specs;
 }
 
 export function conceal(view: EditorView): ConcealSpec[] {

--- a/src/editor_extensions/conceal_fns.ts
+++ b/src/editor_extensions/conceal_fns.ts
@@ -409,15 +409,17 @@ function concealFraction(eqn: string): ConcealSpec[] {
 	return concealSpecs;
 }
 
-function concealOperatorname(eqn) {
+function concealOperatorname(eqn: string): ConcealSpec[] {
 	const regexStr = "\\\\operatorname{([A-Za-z]+)}";
 	const regex = new RegExp(regexStr, "g");
 	const matches = [...eqn.matchAll(regex)];
-	const specs = [];
+	const specs: ConcealSpec[] = [];
+
 	for (const match of matches) {
 		const value = match[1];
-		const start2 = match.index;
+		const start2 = match.index!;
 		const end2 = start2 + match[0].length;
+
 		specs.push(mkConcealSpec({
 			start: start2,
 			end: end2,
@@ -425,6 +427,7 @@ function concealOperatorname(eqn) {
 			class: "cm-concealed-mathrm cm-variable-2"
 		}));
 	}
+
 	return specs;
 }
 

--- a/src/editor_extensions/conceal_fns.ts
+++ b/src/editor_extensions/conceal_fns.ts
@@ -409,6 +409,25 @@ function concealFraction(eqn: string): ConcealSpec[] {
 	return concealSpecs;
 }
 
+function concealOperatorname(eqn) {
+  const regexStr = "\\\\operatorname{([A-Za-z]+)}";
+  const regex = new RegExp(regexStr, "g");
+  const matches = [...eqn.matchAll(regex)];
+  const specs = [];
+  for (const match of matches) {
+    const value = match[1];
+    const start2 = match.index;
+    const end2 = start2 + match[0].length;
+    specs.push(mkConcealSpec({
+      start: start2,
+      end: end2,
+      text: value,
+      class: "cm-concealed-mathrm cm-variable-2"
+    }));
+  }
+  return specs;
+}
+
 export function conceal(view: EditorView): ConcealSpec[] {
 	const specs: ConcealSpec[] = [];
 
@@ -456,7 +475,8 @@ export function conceal(view: EditorView): ConcealSpec[] {
 					...concealBraKet(eqn),
 					...concealSet(eqn),
 					...concealFraction(eqn),
-					...concealOperators(eqn, operators)
+					...concealOperators(eqn, operators),
+					...concealOperatorname(eqn)
 				];
 
 				// Make the 'start' and 'end' fields represent positions in the entire


### PR DESCRIPTION
Conceals \operatorname{anyText} to "anyText" without the quotationmarks