### PR TITLE
Inline Matrix Commands

### DIFF
--- a/src/features/matrix_shortcuts.ts
+++ b/src/features/matrix_shortcuts.ts
@@ -2,7 +2,7 @@ import { EditorView } from "@codemirror/view";
 import { setCursor } from "src/utils/editor_utils";
 import { getLatexSuiteConfig } from "src/snippets/codemirror/config";
 import { Context } from "src/utils/context";
-
+import { tabout } from "src/features/tabout";
 
 export const runMatrixShortcuts = (view: EditorView, ctx: Context, key: string, shiftKey: boolean):boolean => {
 	const settings = getLatexSuiteConfig(view);
@@ -26,7 +26,7 @@ export const runMatrixShortcuts = (view: EditorView, ctx: Context, key: string, 
 		return true;
 	}
 	else if (key === "Enter") {
-		if (shiftKey) {
+		if (shiftKey && ctx.mode.blockMath) {
 			// Move cursor to end of next line
 			const d = view.state.doc;
 
@@ -35,8 +35,12 @@ export const runMatrixShortcuts = (view: EditorView, ctx: Context, key: string, 
 
 			setCursor(view, nextLine.to);
 		}
+		else if (shiftKey && ctx.mode.inlineMath) { 
+			tabout(view, ctx);
+		}
 		else {
-			view.dispatch(view.state.replaceSelection(" \\\\\n"));
+			let lineBreakStr = (ctx.mode.inlineMath) ? " \\\\ " : " \\\\\n";
+			view.dispatch(view.state.replaceSelection(lineBreakStr));
 		}
 
 		return true;

--- a/src/latex_suite.ts
+++ b/src/latex_suite.ts
@@ -89,7 +89,7 @@ export const handleKeydown = (key: string, shiftKey: boolean, ctrlKey: boolean, 
 		}
 	}
 
-	if (settings.matrixShortcutsEnabled && ctx.mode.blockMath) {
+	if (settings.matrixShortcutsEnabled && ctx.mode.strictlyInMath()) {
 		if (["Tab", "Enter"].contains(key)) {
 			success = runMatrixShortcuts(view, ctx, key, shiftKey);
 


### PR DESCRIPTION
Replaces PR #310 , which was accidentally deleted. 

As the previous discussion outlined, we now have the following behavior in inline math:
Tab: inserts an ampersand (&)
Enter: inserts " \\\\ "
Shift-Enter: tabs out of the matrix environment.