### PR TITLE
Restore tabindent for selections

### DIFF
--- a/src/features/matrix_shortcuts.ts
+++ b/src/features/matrix_shortcuts.ts
@@ -19,8 +19,8 @@ export const runMatrixShortcuts = (view: EditorView, ctx: Context, key: string, 
 
 	if (!isInsideAnEnv) return false;
 
-
-	if (key === "Tab") {
+	// Take main cursor since ctx.mode takes the main cursor, weird behaviour is expected with multicursor because of this.
+	if (key === "Tab" && view.state.selection.main.empty) {
 		view.dispatch(view.state.replaceSelection(" & "));
 
 		return true;

--- a/src/latex_suite.ts
+++ b/src/latex_suite.ts
@@ -98,7 +98,10 @@ export const handleKeydown = (key: string, shiftKey: boolean, ctrlKey: boolean, 
 	}
 
 	if (settings.taboutEnabled) {
-		if (key === "Tab" || shouldTaboutByCloseBracket(view, key)) {
+		// check if the main cursor has something selected since ctx.mode only checks the main cursor.
+		//  This does give weird behaviour with multicursor.
+		if ((key === "Tab" && view.state.selection.main.empty) 
+			|| shouldTaboutByCloseBracket(view, key)) {
 			success = tabout(view, ctx);
 
 			if (success) return true;


### PR DESCRIPTION
Implement https://github.com/artisticat1/obsidian-latex-suite/issues/363.

Skip the matrixshortcut and the tabout if something is selected since those actions don't make much sense for selections and indenting would be more reasonable.



Weird behaviour in multicursor is expected but the same weird behaviour is also there without this change.
`ctx.mode` gets the main/last cursor so the main cursor is checked for selections.
Also the weird behaviour is hard to trigger in multicursor.

I don't think its relevant but the weird behaviour is when for example you press tab in the following text
```tex
$$
a|
$$

some text |
```
where | is the cursor. 