### PR TITLE
[FEATURE] add matrix line spacing.

### DIFF
--- a/src/features/matrix_shortcuts.ts
+++ b/src/features/matrix_shortcuts.ts
@@ -39,7 +39,8 @@ export const runMatrixShortcuts = (view: EditorView, ctx: Context, key: string, 
 			tabout(view, ctx);
 		}
 		else {
-			const lineBreakStr = (ctx.mode.inlineMath) ? " \\\\ " : " \\\\\n";
+			const lineBreakStr = (ctx.mode.inlineMath) ? ` \\\\${settings.matrixShortcutsSpacing} `
+				: ` \\\\${settings.matrixShortcutsSpacing}\n`;
 			view.dispatch(view.state.replaceSelection(lineBreakStr));
 		}
 

--- a/src/settings/settings.ts
+++ b/src/settings/settings.ts
@@ -23,6 +23,7 @@ interface LatexSuiteBasicSettings {
 	autofractionSymbol: string;
 	autofractionBreakingChars: string;
 	matrixShortcutsEnabled: boolean;
+	matrixShortcutsSpacing: string;
 	taboutEnabled: boolean;
 	autoEnlargeBrackets: boolean;
 	wordDelimiters: string;
@@ -72,6 +73,7 @@ export const DEFAULT_SETTINGS: LatexSuitePluginSettings = {
 	autofractionSymbol: "\\frac",
 	autofractionBreakingChars: "+-=\t",
 	matrixShortcutsEnabled: true,
+	matrixShortcutsSpacing: "",
 	taboutEnabled: true,
 	autoEnlargeBrackets: true,
 	wordDelimiters: "., +-\\n\t:;!?\\/{}[]()=~$",

--- a/src/settings/settings_tab.ts
+++ b/src/settings/settings_tab.ts
@@ -305,13 +305,26 @@ export class LatexSuiteSettingTab extends PluginSettingTab {
 		const containerEl = this.containerEl;
 		this.addHeading(containerEl, "Matrix shortcuts", "brackets-contain");
 
-		new Setting(containerEl)
+		const matrixShortcut: Setting = new Setting(containerEl)
 			.setName("Enabled")
 			.setDesc("Whether matrix shortcuts are enabled.")
-			.addToggle(toggle => toggle
+
+		const matrixSpacing: Setting = new Setting(containerEl)
+			.setName("Matrix line spacing")
+			.setDesc("The spacing between lines in a matrix environment. For example \\\\[1em] will add 1em of space between lines.")
+			.addText(text => text
+				.setValue(this.plugin.settings.matrixShortcutsSpacing)
+				.onChange(async (value) => {
+					this.plugin.settings.matrixShortcutsSpacing = value;
+					await this.plugin.saveSettings();
+				})
+			);
+
+		matrixShortcut.addToggle(toggle => toggle
 				.setValue(this.plugin.settings.matrixShortcutsEnabled)
 				.onChange(async (value) => {
 					this.plugin.settings.matrixShortcutsEnabled = value;
+					matrixSpacing.settingEl.toggleClass("hidden", !value);
 					await this.plugin.saveSettings();
 				}));
 


### PR DESCRIPTION
Add the option for line spacing for the "Enter" matrix shortcut. For example `[1em]` in the setting becomes `\\[1em]` in the editor. 
Solves https://github.com/artisticat1/obsidian-latex-suite/discussions/381.