### PR TITLE
added mathrm and color to text environments inside math blocks

### DIFF
--- a/src/utils/context.ts
+++ b/src/utils/context.ts
@@ -114,7 +114,9 @@ export class Context {
 			this.isWithinEnvironment(this.pos, {openSymbol: "\\text{", closeSymbol: "}"}) ||
 			this.isWithinEnvironment(this.pos, {openSymbol: "\\tag{", closeSymbol: "}"}) ||
 			this.isWithinEnvironment(this.pos, {openSymbol: "\\begin{", closeSymbol: "}"}) ||
-			this.isWithinEnvironment(this.pos, {openSymbol: "\\end{", closeSymbol: "}"})
+			this.isWithinEnvironment(this.pos, {openSymbol: "\\end{", closeSymbol: "}"}) ||
+			this.isWithinEnvironment(this.pos, {openSymbol: "\\mathrm{", closeSymbol: "}"}) ||
+			this.isWithinEnvironment(this.pos, {openSymbol: "\\color{", closeSymbol: "}"})
 		);
 	}
 


### PR DESCRIPTION
solves https://github.com/artisticat1/obsidian-latex-suite/issues/378.

Ideally I would make this a setting since there are more text environments people may want to use like `\textit`, `\label` or something else but that don't make sense as default options.
But I first want to know if that feature is alright before I work on it.