### PR TITLE
Completed the list of text environments inside math environments. 

### DIFF
--- a/src/utils/context.ts
+++ b/src/utils/context.ts
@@ -5,6 +5,7 @@ import { Mode } from "../snippets/options";
 import { Environment } from "../snippets/environment";
 import { getLatexSuiteConfig } from "../snippets/codemirror/config";
 import { syntaxTree } from "@codemirror/language";
+import { textArea } from "./default_text_areas";
 
 export interface Bounds {
 	start: number;
@@ -110,14 +111,11 @@ export class Context {
 	}
 
 	inTextEnvironment(): boolean {
-		return (
-			this.isWithinEnvironment(this.pos, {openSymbol: "\\text{", closeSymbol: "}"}) ||
-			this.isWithinEnvironment(this.pos, {openSymbol: "\\tag{", closeSymbol: "}"}) ||
-			this.isWithinEnvironment(this.pos, {openSymbol: "\\begin{", closeSymbol: "}"}) ||
-			this.isWithinEnvironment(this.pos, {openSymbol: "\\end{", closeSymbol: "}"}) ||
-			this.isWithinEnvironment(this.pos, {openSymbol: "\\mathrm{", closeSymbol: "}"}) ||
-			this.isWithinEnvironment(this.pos, {openSymbol: "\\color{", closeSymbol: "}"})
-		);
+		for (const env of textArea) {
+			if (this.isWithinEnvironment(this.pos, {openSymbol: `${env}{`, closeSymbol: "}"})) return true;
+		}
+		return false;
+		
 	}
 
 	getBounds(pos: number = this.pos): Bounds {

--- a/src/utils/default_text_areas.ts
+++ b/src/utils/default_text_areas.ts
@@ -1,0 +1,90 @@
+/**
+ * List of environments where math can NEVER be inserted.
+ * this is a mix of text and math environments where for example \color{#1} computes #1 as colorcode
+ * and \textrm{#1} computes #1 as text.
+ * All of these follow the same pattern of \command{#1} where #1 is the input. In rare cases it can be \command{#1}{#2}{#3}. These need to be handled seperately. So the Environment would be {openSymbol: `\command{`, closeSymbol: "}"}
+ * @type {Array<string>}
+ */
+export const textArea: Array<string> = [
+	"text",
+	"textrm",
+	"textup",
+	"textit",
+	"textbf",
+	"textsf",
+	"texttt",
+	"textnormal",
+	"clap",
+	"textllap",
+	"textrlap",
+	"textclap",
+	"hbox",
+	"mbox",
+	"fbox",
+	"framebox",
+	"begin",
+	"end",
+	"tag",
+	"colorbox",
+	"fcolorbox", // has two inputs \fcolorbox{color}{background}{text} needs seperate handling
+	"unicode",
+	"mmlToken", // MathML token, also has two inputs
+];
+
+/**
+ * List of math fonts/ math commands. I don't know if they should treated as text since they are technically math environments.
+ */
+export const mathFonts: Array<string> = [
+	"label", // labels don't work properly in mathjax. See https://physics.meta.stackexchange.com/questions/5396/using-labels-with-mathjax, 
+	// but labels can't be overwritten and everytime the equation is changed the label gets recompiled and the reference is lost till obsidian reloads itself.
+	"ref", // math is allowed for some reason
+	"eqref", // math is allowed for some reason
+	"operatorname",
+	"operatorname*",
+	"DeclareMathOperator",
+	"DeclareMathOperator*",
+	"mathrm",    
+	"mathup", 
+	"mathnormal",
+	"mathbf",    
+	"mathbfup",  
+	"mathit",    
+	"mathbfit",  
+	"mathbb",    
+	"Bbb",       
+	"mathfrak",  
+	"mathbffrak",
+	"mathscr",   
+	"mathbfscr", 
+	"mathsf",    
+	"mathsfup",  
+	"mathbfsf",  
+	"mathbfsfup",
+	"mathsfit",  
+	"mathbfsfit",
+	"mathtt",    
+	"mathcal",   
+	"mathbfcal", 
+	"symrm",     
+	"symup",     
+	"symnormal", 
+	"symbf",     
+	"symbfup",   
+	"symit",     
+	"symbfit",   
+	"symbb",     
+	"symfrak",   
+	"symbffrak", 
+	"symscr",    
+	"symbfscr",  
+	"symsf",     
+	"symsfup",   
+	"symbfsf",   
+	"symbfsfup", 
+	"symsfit",   
+	"symbfsfit", 
+	"symtt",     
+	"symcal",    
+	"symbfcal",  
+	"Bbb",
+];


### PR DESCRIPTION
This adds all the environments that don't accept math input in their arguments to the text environment in the context class.

Besides this another array was added.
It contains the macros where math input would be unusual but is still perfectly valid.
`\label{\alpha}` is for example correct syntax. (`\label` generally doesn't work great in mathjax/obsidian but thats unimportant)

> I think it makes sense to add all text environments one might conceivably use.

How should a text environment be defined. The mathfonts are generally treated as text like environments (from my experience),
but they are still math environments.