### PR TITLE
Enhance matrixShortcuts: Optional whitespace trimming & multi-selection support

### DIFF
--- a/src/features/matrix_shortcuts.ts
+++ b/src/features/matrix_shortcuts.ts
@@ -1,8 +1,44 @@
 import { EditorView } from "@codemirror/view";
+import { EditorSelection, SelectionRange } from "@codemirror/state";
+import { Context } from "src/utils/context";
 import { setCursor } from "src/utils/editor_utils";
 import { getLatexSuiteConfig } from "src/snippets/codemirror/config";
-import { Context } from "src/utils/context";
 import { tabout } from "src/features/tabout";
+
+
+const ALIGNMENT = " & ";
+const LINE_BREAK = " \\\\\n"
+const LINE_BREAK_INLINE = " \\\\ "
+
+
+const generateSeparatorChange = (separator: string, view: EditorView, range: SelectionRange): { from: number, to: number, insert: string } => {
+	const d = view.state.doc;
+
+	// Insert indents
+	const fromLineText = d.lineAt(range.from).text;
+	const leadingIndents = fromLineText.match(/^\s*/)[0];
+	const fixed_separator = separator.replaceAll("\n", `\n${leadingIndents}`);
+
+	return { from: range.from, to: range.to, insert: fixed_separator };
+}
+
+
+const applySeparator = (separator: string, view: EditorView) => {
+	const sel = view.state.selection;
+	const changes = sel.ranges.map(range => generateSeparatorChange(separator, view, range));
+
+	const tempTransaction = view.state.update({ changes });
+
+	const newSelection = EditorSelection.create(
+		changes.map(({ from, to, insert }) =>
+			EditorSelection.cursor(tempTransaction.changes.mapPos(from) + insert.length)
+		),
+		sel.mainIndex
+	);
+
+	view.dispatch(view.state.update({ changes, selection: newSelection }));
+}
+
 
 export const runMatrixShortcuts = (view: EditorView, ctx: Context, key: string, shiftKey: boolean): boolean => {
 	const settings = getLatexSuiteConfig(view);
@@ -19,41 +55,40 @@ export const runMatrixShortcuts = (view: EditorView, ctx: Context, key: string, 
 
 	if (!isInsideAnEnv) return false;
 
-	// Take main cursor since ctx.mode takes the main cursor, weird behaviour is expected with multicursor because of this.
-	if (key === "Tab" && view.state.selection.main.empty) {
-		view.dispatch(view.state.replaceSelection(" & "));
+	if (key === "Tab") {
+		applySeparator(ALIGNMENT, view);
 
 		return true;
 	}
+
 	else if (key === "Enter") {
-		if (shiftKey && ctx.mode.blockMath) {
-			// Move cursor to end of next line
-			const d = view.state.doc;
+		if (shiftKey) {
+			if (ctx.mode.inlineMath) {
+				tabout(view, ctx);
+			}
+			else {
+				// Move cursor to end of next line
+				const d = view.state.doc;
 
-			const nextLineNo = d.lineAt(ctx.pos).number + 1;
-			const nextLine = d.line(nextLineNo);
+				const nextLineNo = d.lineAt(ctx.pos).number + 1;
+				const nextLine = d.line(nextLineNo);
 
-			setCursor(view, nextLine.to);
-		}
-		else if (shiftKey && ctx.mode.inlineMath) {
-			tabout(view, ctx);
-		}
-		else if (ctx.mode.blockMath) {
-			const d = view.state.doc;
-			const lineText = d.lineAt(ctx.pos).text;
-			const matchIndents = lineText.match(/^\s*/);
-			const leadingIndents = matchIndents ? matchIndents[0] : "";
-
-			view.dispatch(view.state.replaceSelection(` \\\\\n${leadingIndents}`));
+				setCursor(view, nextLine.to);
+			}
 		}
 		else {
-			view.dispatch(view.state.replaceSelection(" \\\\ "));
+			if (ctx.mode.inlineMath) {
+				applySeparator(LINE_BREAK_INLINE, view);
+			}
+			else {
+				applySeparator(LINE_BREAK, view);
+			}
 		}
 
 		return true;
 	}
+
 	else {
 		return false;
 	}
-
 }

--- a/src/features/matrix_shortcuts.ts
+++ b/src/features/matrix_shortcuts.ts
@@ -18,22 +18,19 @@ const generateSeparatorChange = (separator: string, view: EditorView, range: Sel
 	const fromLine = d.lineAt(range.from);
 	const toLine = d.lineAt(range.from);
 
-	let fixed_separator = "";
+	let fixed_separator = separator;
 
 	let from = range.from;
 	let to = range.to;
 
 	if (trimWhitespace) {
-		const [, separatorHeadSpace, separatorRemaining] = separator.match(/^([ \t]*)([\s\S]*?)$/);
-
 		const textBeforeFrom = d.sliceString(fromLine.from, range.from).trimStart();  // Preserve indents
 		const textAfterTo = d.sliceString(range.to, toLine.to);
 
-		// If not at the beginning of the line
-		if (textBeforeFrom !== "") {
-			fixed_separator += separatorHeadSpace;
+		// If at the beginning of the line
+		if (textBeforeFrom === "") {
+			fixed_separator = fixed_separator.match(/^[ \t]*([\s\S]*)$/)[1];
 		}
-		fixed_separator += separatorRemaining;
 
 		from -= textBeforeFrom.match(/\s*$/)[0].length;  // Extend selection to include trailing whitespace before `from`
 		to += textAfterTo.match(/^\s*/)[0].length;  // Extend selection to include leading whitespace after `to`

--- a/src/settings/settings.ts
+++ b/src/settings/settings.ts
@@ -23,6 +23,7 @@ interface LatexSuiteBasicSettings {
 	autofractionSymbol: string;
 	autofractionBreakingChars: string;
 	matrixShortcutsEnabled: boolean;
+	matrixShortcutsTrimWhitespace: boolean;
 	taboutEnabled: boolean;
 	autoEnlargeBrackets: boolean;
 	wordDelimiters: string;
@@ -72,6 +73,7 @@ export const DEFAULT_SETTINGS: LatexSuitePluginSettings = {
 	autofractionSymbol: "\\frac",
 	autofractionBreakingChars: "+-=\t",
 	matrixShortcutsEnabled: true,
+	matrixShortcutsTrimWhitespace: true,
 	taboutEnabled: true,
 	autoEnlargeBrackets: true,
 	wordDelimiters: "., +-\\n\t:;!?\\/{}[]()=~$",

--- a/src/settings/settings_tab.ts
+++ b/src/settings/settings_tab.ts
@@ -312,6 +312,7 @@ export class LatexSuiteSettingTab extends PluginSettingTab {
 				.setValue(this.plugin.settings.matrixShortcutsEnabled)
 				.onChange(async (value) => {
 					this.plugin.settings.matrixShortcutsEnabled = value;
+
 					await this.plugin.saveSettings();
 				}));
 
@@ -323,6 +324,17 @@ export class LatexSuiteSettingTab extends PluginSettingTab {
 				.setValue(this.plugin.settings.matrixShortcutsEnvNames)
 				.onChange(async (value) => {
 					this.plugin.settings.matrixShortcutsEnvNames = value;
+
+					await this.plugin.saveSettings();
+				}));
+
+		new Setting(containerEl)
+			.setName("Auto-trim Excess Whitespace")
+			.setDesc("When enabled, Tab and Enter will automatically remove surrounding whitespace to prevent excessive spaces.")
+			.addToggle(toggle => toggle
+				.setValue(this.plugin.settings.matrixShortcutsTrimWhitespace)
+				.onChange(async (value) => {
+					this.plugin.settings.matrixShortcutsTrimWhitespace = value;
 
 					await this.plugin.saveSettings();
 				}));

--- a/src/settings/settings_tab.ts
+++ b/src/settings/settings_tab.ts
@@ -329,8 +329,8 @@ export class LatexSuiteSettingTab extends PluginSettingTab {
 				}));
 
 		new Setting(containerEl)
-			.setName("Auto-trim Excess Whitespace")
-			.setDesc("When enabled, Tab and Enter will automatically remove surrounding whitespace to prevent excessive spaces.")
+			.setName("Trim Excess Whitespace")
+			.setDesc("When enabled, Tab and Enter will trim surrounding whitespace to prevent excessive spaces.")
 			.addToggle(toggle => toggle
 				.setValue(this.plugin.settings.matrixShortcutsTrimWhitespace)
 				.onChange(async (value) => {


### PR DESCRIPTION
### Summary
This PR adds an optional whitespace trimming feature to `matrixShortcuts`.

### Changes
- **New setting**: `matrixShortcutsTrimWhitespace`
- **Functionality**:
  - When enabled, pressing Tab or Enter in a matrix environment will **remove surrounding whitespace** before inserting "&" or "\\\\".
  - **Multi-selection support**: Ensures consistent trimming across multiple cursors.
- **Purpose**: Prevents excessive spaces from affecting LaTeX matrix formatting.

This feature is **enabled by default** and can be disabled in settings.