### PR TITLE
fix: correct obsidian's syntax tree.

### DIFF
--- a/src/utils/context.ts
+++ b/src/utils/context.ts
@@ -221,6 +221,14 @@ export const getEquationBounds = (state: EditorState, pos?: number):Bounds => {
 	const end = escalateToToken(cursor, Direction.Forward, "math-end");
 
 	if (begin && end) {
+		// Deals with the case of $|$\n text and stuff $$equations and stuff\n$$
+		// where text and stuff is seen as blockmath instead of text
+		if (begin.to > pos) {
+			const chars = state.sliceDoc(pos-1, pos+1);
+			if (chars === "$$") {
+				return {start: pos-1, end: pos-1};
+			}
+		}
 		return {start: begin.to, end: end.from};
 	}
 	else {


### PR DESCRIPTION
Currently for the string
$|$
... text
$$
...
$$
where | is the cursor, is the first part recognized as blockmath instead of the second part. Essentially the cursor is outside the math environment but we treat it as if its inside. This then leads to the error behaviour in the autofraction and while technically correct by obsidians syntax, laggy behaviour. This also fixes the inconsistency of the math-preview being on if you're at top $|$ but not being on at the bottom $|$. Now it's never on when you are between $|$.
Fixes #415 #407