### PR TITLE
fix: don't see tags with `math` as an equation

### DIFF
--- a/src/utils/context.ts
+++ b/src/utils/context.ts
@@ -174,7 +174,7 @@ const isWithinEquation = (state: EditorState):boolean => {
 		return (left.name.contains("math") && right.name.contains("math") && !(left.name.contains("math-end")));
 	}
 
-	return (syntaxNode.name.contains("math"));
+	return (syntaxNode.name.contains("math") && !syntaxNode.name.contains("hashtag_hashtag-end_meta_tag"));
 }
 
 const isWithinInlineEquation = (state: EditorState):boolean => {


### PR DESCRIPTION
In obsidian, the name of a tag is the following hashtag_hashtag-end_meta_tag-<tagname>, if this tag name were to contain the word `math`, then it would recognize the whole tag as an equation instead of a tag. Fix is to check if we are not currently in a tag. fixes #431.