### PR TITLE
fix: delayed conceal didn't work on vim

### DIFF
--- a/src/editor_extensions/conceal.ts
+++ b/src/editor_extensions/conceal.ts
@@ -273,6 +273,9 @@ export const mkConcealPlugin = (revealTimeout: number) => ViewPlugin.fromClass(c
 
 		// Invoke the update method to reflect the changes of this.decoration
 		view.dispatch();
+		//TODO: If replit or the future maintainers of vim ever decides to support CM6 (decorations) properly, remove this.
+		//@ts-ignore
+		view?.cm?.signal("vim-command-done");
 	}, revealTimeout, true);
 
 	update(update: ViewUpdate) {


### PR DESCRIPTION
Fixes #429.
codemirror-vim still runs mostly on CM5 code.
Because of that it doesn't deal with decorations correctly. Obsidian already fixed the `movingByCharacter` command, but its not clear from the 7k loc where the cursor position logic can be overwritten.

As such to circumvent this bug we update the cursor with `Vim.enterVimMode(view)`. This seems only update the cursor position in normal mode and otherwise does nothing. This does depend on the unsupported obsidian api of `CodeMirrorAdapter`, but from some online reddit conversations it seems we can keep using this in the near future.

This bug only happens with delayedreveal on,
as the decorations update happens after the initial view update and the vim cursor only gets updated directly after the update causing mismatch.

edit: found out why this works. https://github.com/replit/codemirror-vim/blob/master/src/block-cursor.ts is responsible for drawing the cursor and https://github.com/replit/codemirror-vim/blob/71919db3d4466d487d53aae551ab035a490dd75a/src/index.ts#L75C2-L86C1 specifically in this instance for redrawing the cursor.
>  ```ts
>     this.cm.on("vim-mode-change", (e: any) => {
>        if (!cm.state.vim) return;
>        cm.state.vim.mode = e.mode;
>        if (e.subMode) {
>          cm.state.vim.mode += e.subMode === "linewise" ? " line" : " block";
>        }
>        cm.state.vim.status = "";
>        this.blockCursor.scheduleRedraw();
>        this.updateClass();
>        this.updateStatus();
>      });
>```

I would like to use the raw `CM` object and its `signal` function instead of `Vim.enterVimMode`  but obsidian hides the `CM` that gets binded to the Vim plugin behind some minified code and `view.cm.signal` didn't work so this is the best option.


edit2: checked the source code of the `signal` function and tried that and it worked and I found out that `cm.signal` has a function structure of `(e,n,t) =>...` but it actually is just `(e,n) =>signal(this,e,n)`. So now the fixed code is just `cm.signal("vim-command-done")` as that should have the least amount of side affects while fixing this bug.
