### PR TITLE
[Feature] optimize conceal

### DIFF
--- a/src/editor_extensions/conceal.ts
+++ b/src/editor_extensions/conceal.ts
@@ -252,13 +252,18 @@ export const mkConcealPlugin = (revealTimeout: number) => ViewPlugin.fromClass(c
 	decorations: DecorationSet;
 	atomicRanges: RangeSet<RangeValue>;
 	delayEnabled: boolean;
+	concealSpecs: ConcealSpec[];
+	lastVisibleRange: readonly { from: number, to: number }[] = [];
+	performance_log = {average: 0,weight: 0}
 
 
-	constructor() {
+	constructor(view: EditorView) {
 		this.concealments = [];
 		this.decorations = Decoration.none;
 		this.atomicRanges = RangeSet.empty;
 		this.delayEnabled = revealTimeout > 0;
+		this.concealSpecs = null;
+
 	}
 
 	delayedReveal = debounce((delayedConcealments: Concealment[], view: EditorView) => {
@@ -273,17 +278,55 @@ export const mkConcealPlugin = (revealTimeout: number) => ViewPlugin.fromClass(c
 		view.dispatch();
 	}, revealTimeout, true);
 
+	delayedConceal = debounce((update: ViewUpdate) => {
+		const concealSpecs = conceal(update.view);
+		if (concealSpecs !== null) {
+			this.concealSpecs = concealSpecs;
+			this.updateFromConcealSpecs(concealSpecs, update);
+			update.view.dispatch();
+		} else {
+			// If concealSpecs is null, the syntax tree is not ready.
+			// We try to get the concealSpecs again after a short delay.
+			console.log("syntax tree not ready, retrying...");
+			this.delayedConceal(update);
+		}
+	}, 100, true);
+
 	update(update: ViewUpdate) {
+		
 		if (!(update.docChanged || update.viewportChanged || update.selectionSet))
 			return;
 
 		// Cancel the delayed revealment whenever we update the concealments
+		const start = performance.now();
 		this.delayedReveal.cancel();
+		this.delayedConceal.cancel();
+		if (!update.docChanged && !update.viewportChanged) {
+			this.updateFromConcealSpecs(this.concealSpecs, update);
+		} else {
+			console.log("updating conceal specs");
+			const concealSpecs = conceal(update.view);
+			if (concealSpecs !== null) {
+				this.concealSpecs = concealSpecs;
+				this.updateFromConcealSpecs(concealSpecs, update);
+			} else {
+				// If concealSpecs is null, the syntax tree is not ready.
+				// We try to get the concealSpecs again after a short delay.
+				console.log("syntax tree not ready, retrying...");
+				this.delayedConceal(update);
+			}
+		}
+		this.lastVisibleRange = update.view.visibleRanges;
+		const end = performance.now();
+		const new_avg = (end - start + this.performance_log.average * this.performance_log.weight) / (this.performance_log.weight + 1);
+		this.performance_log = {average: new_avg, weight: this.performance_log.weight + 1};
+		console.log("conceal time:", (end - start).toFixed(2) + "ms", "average:", this.performance_log.average.toFixed(2) + "ms", "count:", this.performance_log.weight);
+	}
+	
+	private updateFromConcealSpecs(concealSpecs: ConcealSpec[], update: ViewUpdate) {
 
 		const selection = update.state.selection;
 		const mousedown = update.view.plugin(livePreviewState)?.mousedown;
-
-		const concealSpecs = conceal(update.view);
 
 		// Collect concealments from the new conceal specs
 		const concealments: Concealment[] = [];
@@ -325,3 +368,11 @@ export const mkConcealPlugin = (revealTimeout: number) => ViewPlugin.fromClass(c
 	decorations: v => v.decorations,
 	provide: plugin => EditorView.atomicRanges.of(view => view.plugin(plugin).atomicRanges),
 });
+
+const compareVisibleRanges = (a: readonly { from: number, to: number }[], b: readonly { from: number, to: number }[]) => {
+	if (a.length !== b.length) return false;
+	for (let i = 0; i < a.length; i++) {
+		if (a[i].from !== b[i].from || a[i].to !== b[i].to) return false;
+	}
+	return true;
+}

--- a/src/editor_extensions/conceal_fns.ts
+++ b/src/editor_extensions/conceal_fns.ts
@@ -1,12 +1,13 @@
 // Conceal functions
 
-import { syntaxTree } from "@codemirror/language";
+import { ensureSyntaxTree, forceParsing, syntaxTree, syntaxTreeAvailable } from "@codemirror/language";
 import { EditorView } from "@codemirror/view";
 import { getEquationBounds } from "src/utils/context";
 import { findMatchingBracket } from "src/utils/editor_utils";
 import { ConcealSpec, mkConcealSpec } from "./conceal";
 import { greek, cmd_symbols, map_super, map_sub, fractions, brackets, mathscrcal, mathbb, operators } from "./conceal_maps";
 
+const ALL_SYMBOLS = {...greek, ...cmd_symbols};
 
 function escapeRegex(regex: string) {
 	const escapeChars = ["\\", "(", ")", "+", "-", "[", "]", "{", "}"];
@@ -431,12 +432,17 @@ function concealOperatorname(eqn: string): ConcealSpec[] {
 	return specs;
 }
 
-export function conceal(view: EditorView): ConcealSpec[] {
+export function conceal(view: EditorView): ConcealSpec[] | null {
 	const specs: ConcealSpec[] = [];
-
+	const maxTo = Math.max(...view.visibleRanges.map(r => r.to))
+	if (!syntaxTreeAvailable(view.state, maxTo)) {
+		console.log(" not ready");
+		return null;
+	}
 	for (const { from, to } of view.visibleRanges) {
-
-		syntaxTree(view.state).iterate({
+		const tree= syntaxTree(view.state)
+		// console.log(tree.length, "treelength")
+		tree.iterate({
 			from,
 			to,
 			enter: (node) => {
@@ -454,7 +460,6 @@ export function conceal(view: EditorView): ConcealSpec[] {
 				const eqn = view.state.doc.sliceString(bounds.start, bounds.end);
 
 
-				const ALL_SYMBOLS = {...greek, ...cmd_symbols};
 
 				const localSpecs = [
 					...concealSymbols(eqn, "\\^", "", map_super),

--- a/src/utils/context.ts
+++ b/src/utils/context.ts
@@ -5,6 +5,7 @@ import { Mode } from "../snippets/options";
 import { Environment } from "../snippets/environment";
 import { getLatexSuiteConfig } from "../snippets/codemirror/config";
 import { syntaxTree } from "@codemirror/language";
+import { Tree } from "@lezer/common";
 
 export interface Bounds {
 	start: number;


### PR DESCRIPTION
Optimize the scrolling when conceal is enabled.
Currently the whole concealment array is being recomputed even though nothing has been changed.
The change is not that much from 4-8 ms to <1ms on my machine, but the little things may add up.

There is also currently a bug, where the syntaxtree hasn't been fully computed yet.
To reproduce: Reload page without saving and go bottom with `G` in vim.
`ensureSyntaxTree(state,to)` can be used or we can debounce a view.dispatch when its not available.
@llakala do you maybe have any comment? `ensureSyntaxTree` didn't take more than 30ms on my machine even with 22,222 words,  but `ensureSyntaxTree` only updates a local tree and not the global syntax tree.

Also the bug is very minor so idk if its worth the extra complexity.