### PR TITLE
feat: better math preview

### DIFF
--- a/src/settings/settings.ts
+++ b/src/settings/settings.ts
@@ -21,6 +21,8 @@ interface LatexSuiteBasicSettings {
 	highlightCursorBracketsEnabled: boolean;
 	mathPreviewEnabled: boolean;
 	mathPreviewPositionIsAbove: boolean;
+	mathPreviewCursor: string;
+	mathPreviewBracketHighlighting: boolean;
 	autofractionSymbol: string;
 	autofractionBreakingChars: string;
 	matrixShortcutsEnabled: boolean;
@@ -72,6 +74,8 @@ export const DEFAULT_SETTINGS: LatexSuitePluginSettings = {
 	highlightCursorBracketsEnabled: true,
 	mathPreviewEnabled: true,
 	mathPreviewPositionIsAbove: true,
+	mathPreviewCursor: "▶",
+	mathPreviewBracketHighlighting: false,
 	autofractionEnabled: true,
 	autofractionSymbol: "\\frac",
 	autofractionBreakingChars: "+-=\t",

--- a/styles.css
+++ b/styles.css
@@ -233,3 +233,7 @@ sup.cm-math, sub.cm-math {
 /* .latex-suite-color-bracket-3 {
     color: #8de15c;
 } */
+
+.latex-suite-math-preview-highlight {
+	background-color: var(--text-selection);
+}


### PR DESCRIPTION
Resolves #151
Resolves #169

places a cursor most left to the current command so `\p|i` goes to `|\pi` such that there isn't a lot switching between errors and not.

Also if its inside bracket/braces (only `{}` as they indicate another level and () and [] are harder to detect because of half-open intervals) we highlight that part to show the cursor is in that region