### PR TITLE
remove conflict with delta greek symbol

### DIFF
--- a/src/default_snippets.js
+++ b/src/default_snippets.js
@@ -109,7 +109,9 @@
 	{trigger: "-+", replacement: "\\mp", options: "mA"},
     {trigger: "...", replacement: "\\dots", options: "mA"},
     {trigger: "nabl", replacement: "\\nabla", options: "mA"},
-    {trigger: "xx", replacement: "\\times", options: "mA"},
+    // The operator nabla is also called del, but using "del" as a trigger conflicts with the greek letter delta.
+	// {trigger: "del", replacement: "\\nabla", options: "mA"},
+	{trigger: "xx", replacement: "\\times", options: "mA"},
     {trigger: "**", replacement: "\\cdot", options: "mA"},
     {trigger: "para", replacement: "\\parallel", options: "mA"},
 


### PR DESCRIPTION
Using the default settings one can't write the delta symbol writing "delta" as this outcompletes to \nabla(i don't know why).
Since we have already the "nabl" trigger I think it is safe to delete the "del" trigger which causes conflicts with the "delta" symbol.



