### PR TITLE
feat: keep indent/blockqoute levels

### DIFF
--- a/src/features/matrix_shortcuts.ts
+++ b/src/features/matrix_shortcuts.ts
@@ -3,6 +3,8 @@ import { setCursor } from "src/utils/editor_utils";
 import { getLatexSuiteConfig } from "src/snippets/codemirror/config";
 import { Context } from "src/utils/context";
 import { tabout } from "src/features/tabout";
+import { queueSnippet } from "src/snippets/codemirror/snippet_queue_state_field";
+import { expandSnippets } from "src/snippets/snippet_management";
 
 export const runMatrixShortcuts = (view: EditorView, ctx: Context, key: string, shiftKey: boolean): boolean => {
 	const settings = getLatexSuiteConfig(view);
@@ -39,12 +41,9 @@ export const runMatrixShortcuts = (view: EditorView, ctx: Context, key: string, 
 			tabout(view, ctx);
 		}
 		else if (ctx.mode.blockMath) {
-			const d = view.state.doc;
-			const lineText = d.lineAt(ctx.pos).text;
-			const matchIndents = lineText.match(/^\s*/);
-			const leadingIndents = matchIndents ? matchIndents[0] : "";
-
-			view.dispatch(view.state.replaceSelection(` \\\\\n${leadingIndents}`));
+			// Keep current indentation and callout characters
+			queueSnippet(view, ctx.pos, ctx.pos, " \\\\\n$0");
+			expandSnippets(view);
 		}
 		else {
 			view.dispatch(view.state.replaceSelection(" \\\\ "));

--- a/src/snippets/codemirror/snippet_queue_state_field.ts
+++ b/src/snippets/codemirror/snippet_queue_state_field.ts
@@ -1,5 +1,8 @@
 import { EditorView, ViewPlugin } from "@codemirror/view";
 import { SnippetChangeSpec } from "./snippet_change_spec";
+import { getIndentUnit, indentString } from "@codemirror/language";
+import { countColumn, EditorState } from "@codemirror/state";
+import { getCharacterAtPos } from "src/utils/editor_utils";
 export const snippetQueuePlugin = ViewPlugin.fromClass(
 	class {
 	private snippetQueue: SnippetChangeSpec[] = [];
@@ -28,10 +31,32 @@ export function getSnippetQueue(view: EditorView) {
 
 
 export function queueSnippet(view: EditorView, from: number, to: number, insert: string, keyPressed?: string) {
-	const snippet = new SnippetChangeSpec(from, to, insert, keyPressed);
+	const snippet = new SnippetChangeSpec(from, to, keepIndentAndCallout(view.state, from, to, insert), keyPressed);
 	getSnippetQueue(view).QueueSnippets([snippet]);
 }
 
+const keepIndentAndCallout = (state: EditorState,from: number, to: number, replacement: string): string => {
+	const line = state.doc.lineAt(to);
+	const lineText = line.text;
+	const calloutAndIndent = lineText.match(/^(>*)(\s*)/);
+	if (!calloutAndIndent) return replacement;
+	const callouts = calloutAndIndent[1];
+	const indentation = calloutAndIndent[2];
+	const originalColIndent = countColumn(indentation, state.tabSize);
+	const indentUnitSize = getIndentUnit(state);
+	const misalignment = originalColIndent % indentUnitSize;
+	replacement = replacement.replace(/\n(\t*)/g, (_, p1) => {
+		// not preserving misalignment when indent level is increased
+		const newColIndent =
+			p1.length * indentUnitSize +
+			originalColIndent -
+			(p1.length && misalignment);
+		const indent = indentString(state, newColIndent);
+		return "\n" + callouts + indent;
+	});
+
+	return replacement;
+}
 export function clearSnippetQueue(view: EditorView) {
 	getSnippetQueue(view).clearSnippetQueue();
 }


### PR DESCRIPTION
When expanding snippets, keep the same indentation and blockqoute level. When a `\t` is after a `\n` then those get converted to the next tablevel.

so you get
```
- some text
    1. more text dm
```
->
```
- some text
    1. more text $$
    
    $$
```
This way matrices can be indented to the proper level and typing in blocklevel isn't that painfull.