### PR TITLE
refactor: cache math bounds, equations and decorations

### DIFF
--- a/src/features/auto_enlarge_brackets.ts
+++ b/src/features/auto_enlarge_brackets.ts
@@ -2,7 +2,7 @@ import { EditorView } from "@codemirror/view";
 import { findMatchingBracket } from "src/utils/editor_utils";
 import { queueSnippet } from "src/snippets/codemirror/snippet_queue_state_field";
 import { expandSnippets } from "src/snippets/snippet_management";
-import { Context } from "src/utils/context";
+import { Context, contextPlugin } from "src/utils/context";
 import { getLatexSuiteConfig } from "src/snippets/codemirror/config";
 
 
@@ -11,10 +11,10 @@ export const autoEnlargeBrackets = (view: EditorView) => {
 	if (!settings.autoEnlargeBrackets) return;
 
 	// The Context needs to be regenerated since changes to the document may have happened before autoEnlargeBrackets was triggered
-	const ctx = Context.fromView(view);
+	const ctx = view.plugin(contextPlugin);
 	const result = ctx.getBounds();
 	if (!result) return false;
-	const {start, end} = result;
+	const {inner_start: start, inner_end: end} = result;
 
 	const text = view.state.doc.toString();
 	const left = "\\left";

--- a/src/features/autofraction.ts
+++ b/src/features/autofraction.ts
@@ -39,7 +39,7 @@ export const runAutoFractionCursor = (view: EditorView, ctx: Context, range: Sel
 	// Get the bounds of the equation
 	const result = ctx.getBounds();
 	if (!result) return false;
-	const eqnStart = result.start;
+	const eqnStart = result.inner_start;
 
 
 	let curLine = view.state.sliceDoc(0, to);

--- a/src/features/editor_commands.ts
+++ b/src/features/editor_commands.ts
@@ -2,14 +2,14 @@ import { Editor } from "obsidian";
 import { EditorView } from "@codemirror/view";
 import { replaceRange, setCursor, setSelection } from "../utils/editor_utils";
 import LatexSuitePlugin from "src/main";
-import { Context } from "src/utils/context";
+import { Context, contextPlugin } from "src/utils/context";
 
 
 function boxCurrentEquation(view: EditorView) {
-	const ctx = Context.fromView(view);
+	const ctx = view.plugin(contextPlugin);
 	const result = ctx.getBounds();
 	if (!result) return false;
-	const {start, end} = result;
+	const {inner_start: start, inner_end: end} = result;
 
 	let equation = "\\boxed{" + view.state.sliceDoc(start, end) + "}";
 
@@ -34,7 +34,7 @@ function getBoxEquationCommand() {
 
 			// @ts-ignore
 			const view = editor.cm;
-			const ctx = Context.fromView(view);
+			const ctx = view.plugin(contextPlugin);
 			const withinEquation = ctx.mode.inMath();
 
 			if (checking) return withinEquation;
@@ -57,7 +57,7 @@ function getSelectEquationCommand() {
 
 			// @ts-ignore
 			const view = editor.cm;
-			const ctx = Context.fromView(view);
+			const ctx = view.plugin(contextPlugin);
 			const withinEquation = ctx.mode.inMath();
 
 			if (checking) return withinEquation;
@@ -66,7 +66,7 @@ function getSelectEquationCommand() {
 
 			const result = ctx.getBounds();
 			if (!result) return false;
-			let {start, end} = result;
+			let {inner_start: start, inner_end: end} = result;
 
 			// Don't include newline characters in the selection
 			const doc = view.state.doc.toString();

--- a/src/latex_suite.ts
+++ b/src/latex_suite.ts
@@ -5,7 +5,7 @@ import { runAutoFraction } from "./features/autofraction";
 import { tabout, shouldTaboutByCloseBracket } from "./features/tabout";
 import { runMatrixShortcuts } from "./features/matrix_shortcuts";
 
-import { Context } from "./utils/context";
+import { contextPlugin } from "./utils/context";
 import { getCharacterAtPos, replaceRange } from "./utils/editor_utils";
 import { setSelectionToNextTabstop } from "./snippets/snippet_management";
 import { removeAllTabstops } from "./snippets/codemirror/tabstops_state_field";
@@ -72,7 +72,7 @@ export const onKeydown = (event: KeyboardEvent, view: EditorView) => {
 export const handleKeydown = (key: string, shiftKey: boolean, ctrlKey: boolean, isIME: boolean, view: EditorView) => {
 
 	const settings = getLatexSuiteConfig(view);
-	const ctx = Context.fromView(view);
+	const ctx = view.plugin(contextPlugin);
 
 	let success = false;
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -14,6 +14,7 @@ import { snippetExtensions } from "./snippets/codemirror/extensions";
 import { mkConcealPlugin } from "./editor_extensions/conceal";
 import { colorPairedBracketsPluginLowestPrec, highlightCursorBracketsPlugin } from "./editor_extensions/highlight_brackets";
 import { cursorTooltipBaseTheme, cursorTooltipField } from "./editor_extensions/math_tooltip";
+import { Context, contextPlugin, mathBoundsPlugin } from "./utils/context";
 
 export default class LatexSuitePlugin extends Plugin {
 	settings: LatexSuitePluginSettings;
@@ -175,6 +176,8 @@ export default class LatexSuitePlugin extends Plugin {
 
 		// Compulsory extensions
 		this.editorExtensions.push([
+			Prec.highest(mathBoundsPlugin.extension),
+			Prec.highest(contextPlugin.extension),
 			getLatexSuiteConfigExtension(this.CMSettings),
 			Prec.highest(EditorView.domEventHandlers({ "keydown": onKeydown })),
 			Prec.highest(EditorView.inputHandler.of(onInput)),


### PR DESCRIPTION
Storing Context as a viewplugin instead of a class such that it wont get called repeatedly and its called on (almost) every update anyways.

Refactored the finding of the math bounds logic by using exact names instead of searching for substrings and using `childBefore` instead of resolve to simplify finding the previous node without dealing with empty lines.

Caching the decorations for each equation, as in most cases at most one equation will be modified and the rest will stay the same, making recomputation of the decorations unnecessary. Increases performance for conceal significantly as the computing takes time but minor improvement for colorbrackets.

Using inner_start,inner_end,outer_start,outer_end to not deal with magic numbers when going to outer_end and deal with cases such as excalidraw where the bouding end math node has a 0 width, see https://github.com/artisticat1/obsidian-latex-suite/discussions/474 and https://github.com/zsviczian/obsidian-excalidraw-plugin/pull/2582.