### PR TITLE
fix: adjust for when syntaxtree is incomplete.

### DIFF
--- a/src/utils/context.ts
+++ b/src/utils/context.ts
@@ -311,9 +311,10 @@ export const mathBoundsPlugin = ViewPlugin.fromClass(
 			// nodes could be unbalanced or unbalanced in the viewport
 			// - e.g., starting with a closing math node or ending with a opening math node
 			if (close_math_nodes.has(temp_math_nodes[0]?.name)) {
-				temp_math_bounds.push(
-					this.computeEquationBounds(view.state, temp_math_nodes[0].from),
-				);
+				const bounds = this.computeEquationBounds(view.state, temp_math_nodes[0].from);
+				if (bounds) {
+					temp_math_bounds.push(bounds);
+				}
 			}
 			const start_i = open_math_nodes.has(temp_math_nodes[0]?.name)
 				? 0


### PR DESCRIPTION
[BUG] Triggers doesnt work anymore since last update? Fixes #481
On large documents the syntaxtree isn't completed so when mathboundsplugin tries to get all bounds within the view and the last one is an opening one
then it can't find the closing one due to incomplete tree and a null value is added. Fixed by checking for null