### PR TITLE
Feat/optimize/snippets5 redoing reverse tabstop

### DIFF
--- a/src/latex_suite.ts
+++ b/src/latex_suite.ts
@@ -118,7 +118,7 @@ export const handleKeydown = (key: string, shiftKey: boolean, ctrlKey: boolean, 
 	}
 
 	if (key === "Tab") {
-		success = setSelectionToNextTabstop(view);
+		success = setSelectionToNextTabstop(view, shiftKey);
 
 		if (success) return true;
 	}

--- a/src/snippets/tabstop.ts
+++ b/src/snippets/tabstop.ts
@@ -1,5 +1,5 @@
 import { ChangeDesc, EditorSelection, SelectionRange } from "@codemirror/state";
-import { Decoration, DecorationSet, EditorView } from "@codemirror/view";
+import { Decoration, DecorationSet, EditorView, WidgetType } from "@codemirror/view";
 import { resetCursorBlink } from "src/utils/editor_utils";
 import { endSnippet } from "./codemirror/history";
 
@@ -103,6 +103,8 @@ export class TabstopGroup {
         while (cur.value != null) {
             if (cur.from != cur.to){
                 ranges.push(cur.value.range(cur.from, cur.to));
+            } else {
+				ranges.push(createFieldMarker(cur.from, cur.to))
             }
             cur.next();
         }
@@ -141,4 +143,16 @@ export function getEditorSelectionEndpoints(sel: EditorSelection) {
     const endpoints = sel.ranges.map(range => EditorSelection.range(range.to, range.to));
 
     return EditorSelection.create(endpoints);
+}
+
+const FieldMarker = Decoration.widget({widget: new class extends WidgetType {
+		toDOM() {
+			const span = document.createElement("span");
+			span.className = "cm-snippetFieldPosition";
+			return span
+		}
+		ignoreEvent() {return false}
+	}})
+function createFieldMarker(from: number, to: number) {
+	return FieldMarker.range(from,to)
 }

--- a/styles.css
+++ b/styles.css
@@ -254,3 +254,11 @@ and limit the height.
 .latex-suite-math-preview-highlight {
 	background-color: var(--text-selection);
 }
+.cm-snippetFieldPosition {
+    vertical-align: text-top;
+    width: 0;
+    height: 1.15em;
+    display: inline-block;
+    margin: 0 -0.7px -.7em;
+    border-left: 1.4px dotted #888;
+  }


### PR DESCRIPTION
add redo and reverse tabstop. Not sure when `$0` a single tabstop without placeholder text gets added if it should be selected or not. In vscode its selected but could be a bit distracting. idk maybe different css?

edit: codemirror also selects what gets appended so probl better to follow that.