### PR TITLE
Fix/skip_size_control

### DIFF
--- a/src/editor_extensions/conceal_fns.ts
+++ b/src/editor_extensions/conceal_fns.ts
@@ -19,7 +19,7 @@ const not_remap: Record<string,string> = Object.fromEntries([
 	...Object.entries(raw_not_remap).sort((a,b) => b[0].length - a[0].length)
 ]);
 
-function escapeRegex(regex: string) {
+export function escapeRegex(regex: string) {
 	const escapeChars = ["\\", "(", ")", "+", "-", "[", "]", "{", "}", "."];
 
 	for (const escapeChar of escapeChars) {

--- a/src/features/auto_enlarge_brackets.ts
+++ b/src/features/auto_enlarge_brackets.ts
@@ -4,7 +4,44 @@ import { queueSnippet } from "src/snippets/codemirror/snippet_queue_state_field"
 import { expandSnippets } from "src/snippets/snippet_management";
 import { getContextPlugin } from "src/utils/context";
 import { getLatexSuiteConfig } from "src/snippets/codemirror/config";
+import { escapeRegex } from "src/editor_extensions/conceal_fns";
 
+
+const sizeControls = [
+	"\\big",
+	"\\Big",
+	"\\bigg",
+	"\\Bigg",
+	"\\bigl",
+	"\\Bigl",
+	"\\biggl",
+	"\\Biggl",
+	"\\bigr",
+	"\\Bigr",
+	"\\biggr",
+	"\\Biggr",
+	"\\left",
+	"\\right",
+];
+const brackets: { [open: string]: string } = {
+	"(": ")",
+	"[": "]",
+	"\\{": "\\}",
+	"\\langle": "\\rangle",
+	"\\lvert": "\\rvert",
+	"\\lVert": "\\rVert",
+	"\\lceil": "\\rceil",
+	"\\lfloor": "\\rfloor",
+};
+const rawParser = [
+	...sizeControls,
+	...Object.keys(brackets),
+	...Object.values(brackets),
+]
+	.map((s) => escapeRegex(s))
+	.sort((a,b) => a.length - b.length)
+	.join("|");
+const parser = new RegExp(rawParser, "g");
 
 export const autoEnlargeBrackets = (view: EditorView) => {
 	const settings = getLatexSuiteConfig(view);
@@ -16,51 +53,47 @@ export const autoEnlargeBrackets = (view: EditorView) => {
 	if (!result) return false;
 	const {inner_start: start, inner_end: end} = result;
 
-	const text = view.state.doc.toString();
+	const text = view.state.sliceDoc(start, end);
 	const left = "\\left";
 	const right = "\\right";
 
 
-	for (let i = start; i < end; i++) {
-
-		const brackets:{[open: string]: string} = {"(": ")", "[": "]", "\\{": "\\}", "\\langle": "\\rangle", "\\lvert": "\\rvert", "\\lVert": "\\rVert", "\\lceil": "\\rceil", "\\lfloor": "\\rfloor"};
-		const openBrackets = Object.keys(brackets);
+	let match: RegExpExecArray | null;
+	let skip: number | null = null;
+	parser.lastIndex = 0;
+	while ((match = parser.exec(text)) !== null) {
 		let found = false;
 		let open = "";
-
-		for (const openBracket of openBrackets) {
-			if (text.slice(i, i + openBracket.length) === openBracket) {
-				found = true;
-				open = openBracket;
-				break;
-			}
+		if (
+			match[0] in brackets &&
+			(skip === null || /\S/.test(text.slice(skip, match.index)))
+		) {
+			found = true;
+			skip = null;
+			open = match[0];
+		} else if (sizeControls.contains(match[0])) {
+			skip = match.index + match[0].length;
 		}
-
 		if (!found) continue;
 		const bracketSize = open.length;
 		const close = brackets[open];
+		const i = match.index;
 
 
-		const j = findMatchingBracket(text, i, open, close, false, end);
+		const j = findMatchingBracket(text, i, open, close, false);
 		if (j === -1) continue;
-
-
-		// If \left and \right already inserted, ignore
-		if ((text.slice(i-left.length, i) === left) && (text.slice(j-right.length, j) === right)) continue;
-
 
 		// Check whether the brackets contain sum, int or frac
 		const bracketContents = text.slice(i+1, j);
 		const containsTrigger = settings.autoEnlargeBracketsTriggers.some(word => bracketContents.contains("\\" + word));
 
 		if (!containsTrigger) {
-			i = j;
 			continue;
 		}
 
 		// Enlarge the brackets
-		queueSnippet(view, i, i+bracketSize, left + open + " ");
-		queueSnippet(view, j, j+bracketSize, " " + right + close);
+		queueSnippet(view, start + i, start + i + bracketSize, left + open + " ");
+		queueSnippet(view, start + j, start + j + bracketSize, " " + right + close);
 	}
 
 	expandSnippets(view);

--- a/src/features/autofraction.ts
+++ b/src/features/autofraction.ts
@@ -16,7 +16,7 @@ export const runAutoFraction = (view: EditorView, ctx: Context): boolean => {
 
 	const success = expandSnippets(view);
 	
-		if (success) {
+	if (success) {
 		autoEnlargeBrackets(view);
 	}
 


### PR DESCRIPTION
fixes #268 if the size control is already defined, don't add \left or right previously only \left or right was checked and not \big bigg bigr etc.