### PR TITLE
feat: add support for ^ and _ for autenlarge brackets

### DIFF
--- a/src/features/auto_enlarge_brackets.ts
+++ b/src/features/auto_enlarge_brackets.ts
@@ -85,7 +85,7 @@ export const autoEnlargeBrackets = (view: EditorView) => {
 
 		// Check whether the brackets contain sum, int or frac
 		const bracketContents = text.slice(i+1, j);
-		const containsTrigger = settings.autoEnlargeBracketsTriggers.some(word => bracketContents.contains("\\" + word));
+		const containsTrigger = settings.autoEnlargeBracketsTriggers.some(word => bracketContents.contains(word));
 
 		if (!containsTrigger) {
 			continue;

--- a/src/features/run_snippets.ts
+++ b/src/features/run_snippets.ts
@@ -89,7 +89,7 @@ const runSnippetCursor = (view: EditorView, ctx: Context, snippetInfo: SnippetIn
 		const triggerKey = (snippet.options.automatic && snippet.type !== "visual") ? key : undefined;
 		queueSnippet(view, start, to, replacement, triggerKey);
 
-		const containsTrigger = settings.autoEnlargeBracketsTriggers.some(word => replacement.contains("\\" + word));
+		const containsTrigger = settings.autoEnlargeBracketsTriggers.some(word => replacement.contains(word));
 		if (debug === "info" || debug === "verbose") {
 			const trigger = snippet.trigger.toString()
 			const triggerKey = snippet.triggerKey ? `<li>Trigger key: ${new Option(snippet.triggerKey).innerHTML}\n</li>` : "";

--- a/src/settings/settings.ts
+++ b/src/settings/settings.ts
@@ -152,7 +152,9 @@ export function processLatexSuiteSettings(snippets: Snippet[], settings: LatexSu
 		autofractionExcludedEnvs: getAutofractionExcludedEnvs(settings.autofractionExcludedEnvs),
 		matrixShortcutsEnvNames: strToArray(settings.matrixShortcutsEnvNames),
 		taboutClosingSymbols: new Set<string>(strToArray(settings.taboutClosingSymbols)),
-		autoEnlargeBracketsTriggers: strToArray(settings.autoEnlargeBracketsTriggers),
+		// Add backslash to triggers that are LaTeX commands
+		autoEnlargeBracketsTriggers: strToArray(settings.autoEnlargeBracketsTriggers)
+			.map(trigger => /[A-Za-z]+/.test(trigger) ? `\\${trigger}` : trigger), 
 		forceMathLanguages: strToArray(settings.forceMathLanguages),
 	}
 }


### PR DESCRIPTION
fixes #417 only add \\ if the first letter is [A-Za-z] as its likely a latex command otherwise treat it as is and moved that back to parsing so no duplicate code.