### PR TITLE
fix: ignore brackets that have different { nesting level.

### DIFF
--- a/src/features/auto_enlarge_brackets.ts
+++ b/src/features/auto_enlarge_brackets.ts
@@ -1,10 +1,10 @@
 import { EditorView } from "@codemirror/view";
-import { findMatchingBracket } from "src/utils/editor_utils";
 import { queueSnippet } from "src/snippets/codemirror/snippet_queue_state_field";
 import { expandSnippets } from "src/snippets/snippet_management";
 import { getContextPlugin } from "src/utils/context";
 import { getLatexSuiteConfig } from "src/snippets/codemirror/config";
 import { escapeRegex } from "src/editor_extensions/conceal_fns";
+import { isContains, inObject } from "src/utils/type_utils";
 
 
 const sizeControls = [
@@ -22,10 +22,9 @@ const sizeControls = [
 	"\\Biggr",
 	"\\left",
 	"\\right",
-];
-const sizeControlPattern = "(?:" + sizeControls.map(escapeRegex).join("|") + "\\s*)$";
-const sizeControlParser = new RegExp(sizeControlPattern, "s");
-const brackets: { [open: string]: string } = {
+] as const;
+const nestingBrackets = ["{", "}"] as const;
+const brackets = {
 	"(": ")",
 	"[": "]",
 	"\\{": "\\}",
@@ -34,22 +33,47 @@ const brackets: { [open: string]: string } = {
 	"\\lVert": "\\rVert",
 	"\\lceil": "\\rceil",
 	"\\lfloor": "\\rfloor",
-};
-const rawParser = [
+} as const;
+const delimiters = [
 	...sizeControls,
-	...Object.keys(brackets),
+	...Object.keys(brackets) as (keyof typeof brackets)[],
 	...Object.values(brackets),
-]
-	.map((s) => escapeRegex(s))
-	.sort((a,b) => a.length - b.length)
-	.join("|");
+] as const
+
+
+const rawParser = [
+	...delimiters
+	.map(escapeRegex)
+	.sort((a, b) => a.length - b.length),
+	...nestingBrackets.map(escapeRegex)
+].join("|")
+
+	;
 const parser = new RegExp(rawParser, "g");
+
+type OpenBracket = keyof typeof brackets;
+type OpenBracketInfo = {
+	index: number;
+	match: OpenBracket;
+	level: number;
+} | {
+	match: OpenBracket;
+	level: number;
+	ignore: true;
+}
+
+type CloseToOpen = {[K in keyof typeof brackets as (typeof brackets)[K]]: K};
+const closeToOpen: CloseToOpen = Object.fromEntries(
+	Object.entries(brackets).map(([open, close]) => [close, open])
+) as CloseToOpen;
+type ParserResult = typeof delimiters[number] | typeof nestingBrackets[number];
+	
+
 
 export const autoEnlargeBrackets = (view: EditorView) => {
 	const settings = getLatexSuiteConfig(view);
 	if (!settings.autoEnlargeBrackets) return;
 
-	// The Context needs to be regenerated since changes to the document may have happened before autoEnlargeBrackets was triggered
 	const ctx = getContextPlugin(view);
 	const result = ctx.getBounds();
 	if (!result) return false;
@@ -59,46 +83,75 @@ export const autoEnlargeBrackets = (view: EditorView) => {
 	const left = "\\left";
 	const right = "\\right";
 
+	/**
+	 * Algorithm: 
+	 * Keep track of all open brackets and remove them once we see a close bracket that closes that bracket.
+	 * Ignoring brackets that have a size control already on either side
+	 * and ignoring brackets that are not on the same scope {}.
+	 */
 
+	const stack: OpenBracketInfo[] = [];
 	let match: RegExpExecArray | null;
-	let skip: number | null = null;
+	let skipNext: number | null = null;
 	parser.lastIndex = 0;
+	// Grouping as `0{1{2}1{3}1}0{4}0` as latex only allows `\left ... \right` within the same scope like this.
+	let nextGroupId = 0;
+	const scopeStack: number[] = [nextGroupId];
+
 	while ((match = parser.exec(text)) !== null) {
-		let found = false;
-		let open = "";
-		if (
-			match[0] in brackets &&
-			(skip === null || /\S/.test(text.slice(skip, match.index)))
-		) {
-			found = true;
-			skip = null;
-			open = match[0];
-		} else if (sizeControls.contains(match[0])) {
-			skip = match.index + match[0].length;
+		const token = match[0] as ParserResult;
+		const index = match.index;
+		if (isContains(sizeControls, token)) {
+			skipNext = index + token.length;
+			continue
+		} else if (isContains(nestingBrackets, token)) {
+			if (token === "{") {
+				scopeStack.push(++nextGroupId);	
+			} else if (scopeStack.length > 1){
+				scopeStack.pop();
+			}
+			continue
+		} else if (inObject(brackets, token)) {
+			if (skipNext === null || /\S/.test(text.slice(skipNext, index))) {
+				stack.push({index, match: token, level: scopeStack[scopeStack.length - 1]});
+			} else if (skipNext !== null) {
+				stack.push({match: token, ignore: true, level: scopeStack[scopeStack.length - 1]});
+			}
+			skipNext = null;
+			continue
 		}
-		if (!found) continue;
-		const bracketSize = open.length;
-		const close = brackets[open];
-		const i = match.index;
+		const skipCurrent = skipNext !== null && !/\S/.test(text.slice(skipNext, index));
+		skipNext = null;
+		const expectedOpen = closeToOpen[token];
+		for (let i = stack.length - 1; i >= 0; i--) {
+			const openMatch = stack[i];
+			if (openMatch.match === expectedOpen && ("ignore" in openMatch || skipCurrent)) {
+				stack.splice(i, 1);
+				break;
+			}
+			// Same nesting level because ({[)})-> `\left({[\right)})` is invalid latex.
+			if ("ignore" in openMatch) continue;
+			if (openMatch.level !== scopeStack[scopeStack.length - 1]) continue;
+			if (openMatch.match !== expectedOpen) continue;
 
+			const openStart = openMatch.index;
+			const openToken = openMatch.match;
+			const openEnd = openStart + openToken.length;
+			const closeStart = match.index;
 
-		const j = findMatchingBracket(text, i, open, close, false);
-		if (j === -1) continue;
+			const bracketContents = text.slice(openEnd, closeStart);
 
-		// Check whether the brackets contain sum, int or frac
-		const bracketContents = text.slice(i+1, j);
-		const containsTrigger = settings.autoEnlargeBracketsTriggers.some(word => bracketContents.contains(word));
+			const containsTrigger = settings.autoEnlargeBracketsTriggers.some(word =>
+				bracketContents.contains(word)
+			);
+			if (!containsTrigger) break;
 
-		if (!containsTrigger) {
-			continue;
+			queueSnippet(view, start + openStart, start + openEnd, left + openToken + " ");
+			queueSnippet(view, start + closeStart, start + closeStart + token.length, " " + right + token);
+
+			stack.splice(i, 1);
+			break;
 		}
-		if (sizeControlParser.test(bracketContents)) {
-			continue;
-		}
-
-		// Enlarge the brackets
-		queueSnippet(view, start + i, start + i + bracketSize, left + open + " ");
-		queueSnippet(view, start + j, start + j + bracketSize, " " + right + close);
 	}
 
 	expandSnippets(view);

--- a/src/utils/type_utils.ts
+++ b/src/utils/type_utils.ts
@@ -1,0 +1,14 @@
+
+export function isContains<T extends readonly unknown[]>(
+	array: T,
+	value: unknown,
+): value is T[number] {
+	return array.includes(value);
+}
+
+export function inObject<T extends Record<string, unknown>>(
+	obj: T,
+	key: unknown,
+): key is keyof T {
+	return (key as keyof T) in obj;
+}


### PR DESCRIPTION
Fixes #348 
`\left({[\right)})` is invalid latex because it has different nesting levels of `{`. Also only ignore sizeControlls like `\big` or `\right` if they are right next to the end with whitespace allowed instead of in between.

Also use a stack to keep track of opening and closing brackets instead searching the text every time.