### PR TITLE
fix: escpae \{,\} when highlighting in math_tooltip

### DIFF
--- a/src/editor_extensions/math_tooltip.ts
+++ b/src/editor_extensions/math_tooltip.ts
@@ -90,8 +90,10 @@ export function handleMathTooltip(update: ViewUpdate) {
 	const eqnPos = normalizedPos - eqnBounds.inner_start;
 
 	let eqnWithDecorations: string;
+	// skip \{\} as thats not an argument to a macro
+	const tempEscapedEqn = eqn.replaceAll(/\\[\\{}]/g, "\\R")
 	const { left, right } = settings.mathPreviewBracketHighlighting
-		? findMatchingBrackets(eqn, eqnPos, "{", "}")
+		? findMatchingBrackets(tempEscapedEqn, eqnPos, "{", "}")
 		: { left: -1, right: -1 };
 
 	if (right !== -1 && left !== -1) {


### PR DESCRIPTION
Fixes #519
When highlighting the innermost {}, \{\} wasnt ignored, leading to syntax errors when \left \right was used.
Now they are escaped by replacing them temporary with \R