### PR TITLE
fix: treat environment names as text

### DIFF
--- a/src/default_snippets.js
+++ b/src/default_snippets.js
@@ -16,7 +16,8 @@
 		description: "Display math when in a list"
 	},
 
-	{trigger: "beg", replacement: "\\begin{$0}\n$1\n\\end{$0}", options: "mA"},
+	{trigger: /(?:(?<=[^\\])|^)beg]))/, replacement: "\\begin{$0}\n\t$1\n\\end{$0}", options: "MA"},
+	{trigger: /(?:(?<=[^\\])|^)beg]))/, replacement: "\\begin{$0} $1 \\end{$0}", options: "nA"},
 
     // Dashes
 	// {trigger: "--", replacement: "–", options: "tA"},

--- a/src/utils/default_text_areas.ts
+++ b/src/utils/default_text_areas.ts
@@ -90,6 +90,8 @@ const mathFonts = [
 	"symcal",    
 	"symbfcal",  
 	"Bbb",
+	"begin",
+	"end",
 ] as const;
 
 export const mathFontsEnvsRaw = `[${mathFonts.map(env => `\n\t["${env}", "}"]`)}\n]`;


### PR DESCRIPTION
Fixes #522
treat environment names inside `\begin{...}` and `\end{...}` as text it only allows text withiut macros.
TODO: create a snippetless context.
Also updated the beg snippet for inline and display math and only trigger when there isn't a \ before.