### PR TITLE
feat: add snippetless mode for certain macros

### DIFF
--- a/src/features/matrix_shortcuts.ts
+++ b/src/features/matrix_shortcuts.ts
@@ -5,12 +5,13 @@ import { Context } from "src/utils/context";
 import { tabout } from "src/features/tabout";
 import { queueSnippet } from "src/snippets/codemirror/snippet_queue_state_field";
 import { expandSnippets } from "src/snippets/snippet_management";
+import { Environment } from "src/snippets/environment";
 
 export const runMatrixShortcuts = (view: EditorView, ctx: Context, key: string, shiftKey: boolean): boolean => {
 	const settings = getLatexSuiteConfig(view);
 
 	// Check whether we are inside a matrix / align / case environment
-	let isInsideAnEnv = false;
+	let isInsideAnEnv: null | Environment = null;
 
 	for (const envName of settings.matrixShortcutsEnvNames) {
 		const env = { openSymbol: "\\begin{" + envName + "}", closeSymbol: "\\end{" + envName + "}" };

--- a/src/utils/context.ts
+++ b/src/utils/context.ts
@@ -6,7 +6,7 @@ import { Environment } from "../snippets/environment";
 import { getLatexSuiteConfig } from "../snippets/codemirror/config";
 import { syntaxTree } from "@codemirror/language";
 import { SyntaxNode, SyntaxNodeRef } from "@lezer/common";
-import { textAreaEnvs } from "./default_text_areas";
+import { snippetLessArea, textAreaEnvs } from "./default_text_areas";
 
 const OPEN_INLINE_MATH_NODE = "formatting_formatting-math_formatting-math-begin_keyword_math";
 const CLOSE_INLINE_MATH_NODE = "formatting_formatting-math_formatting-math-end_keyword_math_math-";
@@ -88,18 +88,25 @@ export const contextPlugin = ViewPlugin.fromClass(
 		}
 
 		if (inMath) {
-			this.mode.textEnv = this.inTextEnvironment();
+			const textEnv = this.inTextEnvironment();
+			if (textEnv === "text") {
+				this.mode.textEnv = true;
+			} else if (textEnv === "none") {
+				this.mode.inlineMath = false;
+				this.mode.blockMath = false;
+				this.mode.codeMath = false;
+			}
 		}
 
 		this.mode.text = !inCode && !inMath;
 
 	}
 
-	isWithinEnvironment(pos: number, envs: Environment | Environment[]): boolean {
-		if (!this.mode.inMath()) return false;
+	isWithinEnvironment<T extends Environment>(pos: number, envs: T | T[]): T | null {
+		if (!this.mode.inMath()) return null;
 
 		const bounds = this.getInnerBounds();
-		if (!bounds) return false;
+		if (!bounds) return null;
 
 		const {inner_start: start, inner_end: end} = bounds;
 		const text = this.state.sliceDoc(start, end);
@@ -146,7 +153,7 @@ export const contextPlugin = ViewPlugin.fromClass(
 
 				// Check whether the cursor lies inside the environment symbols
 				if (right >= pos && pos >= left + env.openSymbol.length) {
-					return true;
+					return env;
 				}
 
 				if (left <= 0) continue outer_loop;
@@ -156,11 +163,18 @@ export const contextPlugin = ViewPlugin.fromClass(
 			}
 		}
 
-		return false;
+		return null;
 	}
 
-	inTextEnvironment(): boolean {
-		return this.isWithinEnvironment(this.pos, textAreaEnvs)
+	inTextEnvironment(): "text" | "none" | null {
+		const result = this.isWithinEnvironment(this.pos, textAreaEnvs)
+		if (!result) return null;
+		const openSymbol = result.openSymbol.slice(1, -1);
+		if (snippetLessArea.includes(openSymbol as (typeof snippetLessArea)[number])) {
+			return "none"
+		} else {
+			return "text"
+		}
 	}
 
 	getBounds(pos: number = this.pos): Bounds | null {

--- a/src/utils/default_text_areas.ts
+++ b/src/utils/default_text_areas.ts
@@ -21,18 +21,26 @@ const textArea = [
 	"mbox",
 	"fbox",
 	"framebox",
-	"begin",
-	"end",
-	"tag",
 	"colorbox",
 	"fcolorbox", // has two inputs \fcolorbox{color}{background}{text} needs seperate handling
-	"unicode",
-	"mmlToken", // MathML token, also has two inputs
-	"begin",
-	"end",
 ] as const;
 
-export const textAreaEnvs: Array<{ openSymbol: `\\${typeof textArea[number]}{`, closeSymbol: "}" }> = textArea.map(env => {
+/**
+ * List of environments where math commands are illegal to insert.
+ * Here treating them as text also doesn't make sense so autocomplete/snippets are disabled for them.
+ */
+export const snippetLessArea =[
+	"tag",
+	"begin",
+	"end",
+	"mmlToken", // MathML token, also has two inputs
+	"unicode",
+] as const
+
+export const textAreaEnvs: {
+	openSymbol: `\\${(typeof textArea)[number] | (typeof snippetLessArea)[number]}{`;
+	closeSymbol: "}";
+}[] = [...textArea, ...snippetLessArea].map((env) => {
 	return { openSymbol: `\\${env}{`, closeSymbol: "}" };
 });
 


### PR DESCRIPTION
Fixes #526
Macros such as `\begin` or `\mmlToken` can't contain math macros or text macros/markdown syntax, thus snippets are disabled completely for them.
Snippets for these environments would be incredibly niche that for now its better to turn it off entirely.