### PR TITLE
feat: allow overriding of math preview

### DIFF
--- a/src/editor_extensions/math_tooltip.ts
+++ b/src/editor_extensions/math_tooltip.ts
@@ -47,8 +47,13 @@ const findMatchingBrackets = (text: string, cursorPos: number, openBracket: stri
 	return { left, right };
 }
 
+export type MathRenders = {
+	renderMath: typeof renderMath,
+	finishRenderMath: typeof finishRenderMath,
+}
 // update the tooltip by dispatching an updateTooltipEffect
-export function handleMathTooltip(update: ViewUpdate) {
+export function handleMathTooltip(update: ViewUpdate, mathRenders: MathRenders) {
+	const {renderMath, finishRenderMath} = mathRenders;
 	const shouldUpdate = update.docChanged || update.selectionSet;
 	if (!shouldUpdate) return;
 	const settings = getLatexSuiteConfig(update.state);

--- a/src/latex_suite.ts
+++ b/src/latex_suite.ts
@@ -16,13 +16,13 @@ import { handleMathTooltip } from "./editor_extensions/math_tooltip";
 import { isComposing, forceEndComposition } from "./utils/editor_utils";
 import { LatexSuiteCMSettings } from "./settings/settings";
 
-export const handleUpdate = (update: ViewUpdate) => {
+export const handleUpdate = (update: ViewUpdate, mathRenders: MathRenders) => {
 	const settings = getLatexSuiteConfig(update.state);
 
 	// The math tooltip handler is driven by view updates because it utilizes
 	// information about visual line, which is not available in EditorState
 	if (settings.mathPreviewEnabled) {
-		handleMathTooltip(update);
+		handleMathTooltip(update, mathRenders);
 	}
 
 	handleUndoRedo(update);

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,5 +1,5 @@
 import { Extension, Prec } from "@codemirror/state";
-import { Plugin, Notice, loadMathJax, addIcon } from "obsidian";
+import { Plugin, Notice, loadMathJax, addIcon, renderMath, finishRenderMath } from "obsidian";
 import { onFileCreate, onFileChange, onFileDelete, getSnippetsFromFiles, getFileSets, getVariablesFromFiles, tryGetVariablesFromUnknownFiles } from "./settings/file_watch";
 import { LatexSuitePluginSettings, DEFAULT_SETTINGS, LatexSuiteCMSettings, processLatexSuiteSettings } from "./settings/settings";
 import { isIMESupported, LatexSuiteSettingTab } from "./settings/settings_tab";
@@ -21,6 +21,7 @@ export default class LatexSuitePlugin extends Plugin {
 	settings: LatexSuitePluginSettings;
 	CMSettings: LatexSuiteCMSettings;
 	editorExtensions: Extension[] = [];
+	mathRenders = {renderMath, finishRenderMath};
 
 	async onload() {
 		await this.loadSettings();
@@ -182,7 +183,7 @@ export default class LatexSuitePlugin extends Plugin {
 			getLatexSuiteConfigExtension(this.CMSettings),
 			Prec.highest(keyboardEventPlugin.extension),
 			Prec.highest(EditorView.inputHandler.of(onInput)),
-			EditorView.updateListener.of(handleUpdate),
+			EditorView.updateListener.of((update) => handleUpdate(update, this.mathRenders)),
 			snippetExtensions,
 		]);
 		


### PR DESCRIPTION
Fixes #515
User could want the math preview not leak into the mathjax global scope or do other stuff, this is a unofficial/expirmental way of supporting that.