### PR TITLE
fix: Shift enter needs to exit matrix

### DIFF
--- a/src/features/matrix_shortcuts.ts
+++ b/src/features/matrix_shortcuts.ts
@@ -2,25 +2,19 @@ import { EditorView } from "@codemirror/view";
 import { setCursor } from "src/utils/editor_utils";
 import { getLatexSuiteConfig } from "src/snippets/codemirror/config";
 import { Context } from "src/utils/context";
-import { tabout } from "src/features/tabout";
 import { queueSnippet } from "src/snippets/codemirror/snippet_queue_state_field";
 import { expandSnippets } from "src/snippets/snippet_management";
-import { Environment } from "src/snippets/environment";
 
 export const runMatrixShortcuts = (view: EditorView, ctx: Context, key: string, shiftKey: boolean): boolean => {
 	const settings = getLatexSuiteConfig(view);
 
+	const envs = settings.matrixShortcutsEnvNames.map((envName) => ({
+		openSymbol: "\\begin{" + envName + "}",
+		closeSymbol: "\\end{" + envName + "}",
+	}));
 	// Check whether we are inside a matrix / align / case environment
-	let isInsideAnEnv: null | Environment = null;
-
-	for (const envName of settings.matrixShortcutsEnvNames) {
-		const env = { openSymbol: "\\begin{" + envName + "}", closeSymbol: "\\end{" + envName + "}" };
-
-		isInsideAnEnv = ctx.isWithinEnvironment(ctx.pos, env);
-		if (isInsideAnEnv) break;
-	}
-
-	if (!isInsideAnEnv) return false;
+	const envBounds = ctx.isWithinEnvironment(ctx.pos, envs);
+	if (!envBounds) return false;
 
 	// Take main cursor since ctx.mode takes the main cursor, weird behaviour is expected with multicursor because of this.
 	if (key === "Tab" && view.state.selection.main.empty) {
@@ -39,7 +33,7 @@ export const runMatrixShortcuts = (view: EditorView, ctx: Context, key: string, 
 			setCursor(view, nextLine.to);
 		}
 		else if (shiftKey && ctx.mode.inlineMath) {
-			tabout(view, ctx);
+			setCursor(view, envBounds.outer_end);
 		}
 		else if (ctx.mode.blockMath) {
 			// Keep current indentation and callout characters

--- a/src/utils/context.ts
+++ b/src/utils/context.ts
@@ -115,7 +115,7 @@ export const contextPlugin = ViewPlugin.fromClass(
 
 	}
 
-	isWithinEnvironment<T extends Environment>(pos: number, envs: T | T[]): T | null {
+	isWithinEnvironment<T extends Environment>(pos: number, envs: T | T[]): T & Bounds | null {
 		if (!this.mode.inMath()) return null;
 
 		const bounds = this.getInnerBounds();
@@ -166,7 +166,13 @@ export const contextPlugin = ViewPlugin.fromClass(
 
 				// Check whether the cursor lies inside the environment symbols
 				if (right >= pos && pos >= left + env.openSymbol.length) {
-					return env;
+					return {
+						...env,
+						inner_start: left + env.openSymbol.length + start,
+						inner_end: right + start,
+						outer_start: left + start,
+						outer_end: right + env.closeSymbol.length + start,
+					};
 				}
 
 				if (left <= 0) continue outer_loop;


### PR DESCRIPTION
Currently  when there is a closing brace, it chooses that one for inline matrix shortcuts for Shift-enter, while it should exit the matrix just like in display math. Fixed by adding bounds that are gathered from isWithinEnvironment and apply the bounds.