### PR TITLE
feat: auto-add cells in align

### DIFF
--- a/src/features/matrix_shortcuts.ts
+++ b/src/features/matrix_shortcuts.ts
@@ -7,12 +7,15 @@ import { expandSnippets } from "src/snippets/snippet_management";
 
 const newlineMatrixShortcutCallback = (view: EditorView): boolean => {
 	const ctx = getContextPlugin(view);
+	const cur_line = view.state.doc.lineAt(ctx.pos);
+	const current_matrix_line = cur_line.text.match(/(?<=\\begin{[^]]*}|\\\\|^)(\s|\&)+/);
+	const added_cells = current_matrix_line?.[0].trimStart() ?? ""
 	if (ctx.mode.blockMath) {
 		// Keep current indentation and callout characters
-		queueSnippet(view, ctx.pos, ctx.pos, " \\\\\n$0");
+		queueSnippet(view, ctx.pos, ctx.pos, ` \\\\\n${added_cells}$0`);
 		expandSnippets(view);
 	} else {
-		view.dispatch(view.state.replaceSelection(" \\\\ "));
+		view.dispatch(view.state.replaceSelection(` \\\\  ${added_cells}`));
 	}
 	return true;
 };


### PR DESCRIPTION
Fixes #221, #530

When in a matrix env, add the empty cells. Useful for align where you usually start with an empty cell/ begin with &= or &< etc.

partially implements #394. Will look later at that pr to see how to implement it further as I don't think the pr is gonna worked on further