### PR TITLE
fix: priority tabout was using opening delimiters instead of closing

### DIFF
--- a/src/features/tabout.ts
+++ b/src/features/tabout.ts
@@ -183,7 +183,11 @@ export const taboutByEnclosedBrackets = (view: EditorView, latexString: string):
 
 	const delimiter_stack: string[] = [];
 	const closing_delimiters = intersection(new Set<string>(Object.values(DELIMITERS_MAP)), closingSymbols);
-	const opening_delimiters = new Set(Object.keys(DELIMITERS_MAP).filter(key => closing_delimiters.has(key)));
+	const opening_delimiters = new Set(
+		Object.keys(DELIMITERS_MAP).filter((key: keyof typeof DELIMITERS_MAP) =>
+			closing_delimiters.has(DELIMITERS_MAP[key]),
+		),
+	);
 	for (let i = 0; i < tokens.length; i++) {
 		const token = tokens[i];
 		if (closing_delimiters.has(token.text)) {

--- a/src/latex_suite.ts
+++ b/src/latex_suite.ts
@@ -213,7 +213,7 @@ export function getKeymaps(settings: LatexSuiteCMSettings): LatexSuiteKeyBinding
 		},
 	];
 	if (settings.taboutEnabled && settings.taboutTrigger === "Tab") {
-		keybindings.unshift({
+		matrixShortcuts.unshift({
 			key: settings.taboutTrigger,
 			run: priorityTaboutMatrixShortcut
 		})


### PR DESCRIPTION
to  pop items of the delimiter stack it was using the opening delimiter stack instead of the closing one. and the whole keymap was unshifted instead of the matrixshortcuts.