### PR TITLE
feat: recursive snippets

### DIFF
--- a/src/features/run_snippets.ts
+++ b/src/features/run_snippets.ts
@@ -4,7 +4,7 @@ import { getLatexSuiteConfig } from "src/snippets/codemirror/config";
 import { queueSnippet } from "src/snippets/codemirror/snippet_queue_state_field";
 import { Mode, Options } from "src/snippets/options";
 import { expandSnippets } from "src/snippets/snippet_management";
-import { Context } from "src/utils/context";
+import { Context, getContextPlugin } from "src/utils/context";
 import { autoEnlargeBrackets } from "./auto_enlarge_brackets";
 import { snippetDebugLevel } from "src/settings/settings";
 import { Notice } from "obsidian";
@@ -14,26 +14,36 @@ type SnippetInfo = {
 	snippets: Snippet<SnippetType>[];
 	key?: string;
 }
-
+type RunSnippetsOptions = {
+	recursive: number;
+	debug: snippetDebugLevel;
+}
 let lastNotice: Notice | null = null;
-export const runSnippets = (view: EditorView, ctx: Context, snippetInfo: SnippetInfo, debug: snippetDebugLevel):boolean => {
+export const runSnippets = (view: EditorView, snippetInfo: SnippetInfo, options: RunSnippetsOptions):boolean => {
+	let didExpand = false;
+	for (let i=0; i <= options.recursive; i++) {
+		const ctx = getContextPlugin(view);
+		let shouldAutoEnlargeBrackets = false;
 
-	let shouldAutoEnlargeBrackets = false;
+		for (const range of ctx.ranges) {
+			const result = runSnippetCursor(view, ctx, snippetInfo, range, options.debug);
 
-	for (const range of ctx.ranges) {
-		const result = runSnippetCursor(view, ctx, snippetInfo, range, debug);
+			if (result.shouldAutoEnlargeBrackets) shouldAutoEnlargeBrackets = true;
+		}
 
-		if (result.shouldAutoEnlargeBrackets) shouldAutoEnlargeBrackets = true;
+		const success = expandSnippets(view);
+		didExpand = didExpand || success;
+
+
+		if (shouldAutoEnlargeBrackets) {
+			autoEnlargeBrackets(view);
+		}
+		if (!success) {
+			break
+		}
+		snippetInfo.key = undefined; // only run keypress once.
 	}
-
-	const success = expandSnippets(view);
-
-
-	if (shouldAutoEnlargeBrackets) {
-		autoEnlargeBrackets(view);
-	}
-
-	return success;
+	return didExpand
 }
 
 

--- a/src/latex_suite.ts
+++ b/src/latex_suite.ts
@@ -90,7 +90,8 @@ export const handleKeydown = (key: string, ctrlKey: boolean, isIME: boolean, vie
 	}
 	const snippets = settings.snippets.filter((s) => s.options.automatic);
 	try {
-		if (runSnippets(view, ctx, {snippets, key}, settings.snippetDebug)) return true;
+		const options = {recursive: settings.snippetRecursion, debug: settings.snippetDebug};
+		if (runSnippets(view, {snippets, key}, options)) return true;
 	} catch (e) {
 		clearSnippetQueue(view);
 		console.error(e);
@@ -153,7 +154,8 @@ export function getKeymaps(settings: LatexSuiteCMSettings): LatexSuiteKeyBinding
 				return false;
 			try {
 				const ctx = getContextPlugin(view);
-				return runSnippets(view, ctx, {snippets}, settings.snippetDebug);
+				const options = {recursive: settings.snippetRecursion, debug: settings.snippetDebug};
+				return runSnippets(view, {snippets}, options);
 			} catch (e) {
 				clearSnippetQueue(view);
 				console.error(e);

--- a/src/settings/settings.ts
+++ b/src/settings/settings.ts
@@ -38,6 +38,7 @@ interface LatexSuiteBasicSettings {
 	vimSelectMode: VimKeyMap;
 	vimVisualMode: VimKeyMap;
 	vimMatrixEnter: VimKeyMap;
+	snippetRecursion: number;
 
 }
 
@@ -120,6 +121,7 @@ export const DEFAULT_SETTINGS: LatexSuitePluginSettings = {
 	vimSelectMode: "<C-g>",
 	vimVisualMode: "<C-g>",
 	vimMatrixEnter: "o",
+	snippetRecursion: 0,
 }
 
 export function processLatexSuiteSettings(snippets: Snippet[], settings: LatexSuitePluginSettings):LatexSuiteCMSettings {

--- a/src/settings/settings_tab.ts
+++ b/src/settings/settings_tab.ts
@@ -1,6 +1,6 @@
 import { EditorState, Extension } from "@codemirror/state";
 import { EditorView, ViewUpdate } from "@codemirror/view";
-import { App, ButtonComponent, ExtraButtonComponent, Modal, Platform, PluginSettingTab, Setting, debounce, setIcon } from "obsidian";
+import { App, ButtonComponent, ExtraButtonComponent, Modal, Notice, Platform, PluginSettingTab, Setting, debounce, setIcon } from "obsidian";
 import { parseKeyName, parseSnippetVariables, parseSnippets } from "src/snippets/parse";
 import { DEFAULT_SNIPPETS } from "src/utils/default_snippets";
 import LatexSuitePlugin from "../main";
@@ -35,6 +35,7 @@ export class LatexSuiteSettingTab extends PluginSettingTab {
 		iconEl.addClass("latex-suite-settings-icon");
 
 		parentEl.prepend(iconEl);
+		return heading;
 	}
 
 	display(): void {
@@ -50,6 +51,7 @@ export class LatexSuiteSettingTab extends PluginSettingTab {
 		this.displayTaboutSettings();
 		this.displayAutoEnlargeBracketsSettings();
 		this.displayAdvancedSnippetSettings();
+		this.displayExperimentalSettings();
 	}
 
 	private displaySnippetSettings() {
@@ -667,6 +669,37 @@ export class LatexSuiteSettingTab extends PluginSettingTab {
 				}
 				});
 		});
+	}
+	
+	private displayExperimentalSettings() {
+		const containerEl = this.containerEl;
+		this.addHeading(containerEl, "Experimental features", "experiment")
+			.setDesc("Features that are still in testing and may need user feedback. Backwards compatibility may break for these features/ these settings can be overriden.");
+		const fragment = new DocumentFragment()
+		const span = fragment.createDiv({
+			text: "How many times to run snippets in a row. Set to 0 disable recursion. ",
+		});
+		span.createEl("a", {href: "https://github.com/artisticat1/obsidian-latex-suite/pull/536", text: "Related pr/feedback."})
+		new Setting(containerEl)
+			.setName("Snippet recursion")
+			.setDesc(fragment)
+			.addText(text => text
+				.setPlaceholder(String(DEFAULT_SETTINGS.snippetRecursion))
+				.setValue(String(this.plugin.settings.snippetRecursion))
+				.onChange(async (value) => {
+					try {
+						const snippetRecurisve = parseInt(value, 10);
+						if (snippetRecurisve < 0) {
+							new Notice("Snippet recursion must be a non-negative integer.");
+							return;
+						}
+						this.plugin.settings.snippetRecursion = snippetRecurisve;
+					} catch (e) {
+						return
+					}
+					await this.plugin.saveSettings();
+				})
+			);
 	}
 
 	createSnippetsEditor(snippetsSetting: Setting) {


### PR DESCRIPTION
Fixes #535
Fixes https://github.com/artisticat1/obsidian-latex-suite/discussions/473
Allow snippets to trigger other snippets, could make writing snippets a bit easier. Experimental for now because it might be wrong to give the user this control.