### PR TITLE
feat: skip key insertion in automatic snippets

### DIFF
--- a/DOCS.md
+++ b/DOCS.md
@@ -43,6 +43,7 @@
 - `c` : Code mode. Only run this snippet inside a ```` ``` ... ``` ```` block
 	- Languages using `$` as part of their syntax won't trigger math mode while in their codeblock
 	- The `math` language from https://github.com/ocapraro/obsidian-math-plus doesn't trigger code mode, but block math mode instead
+- `U`: Skip undo. When an automatic snippet expands, undo returns the editor to the state before the triggering key was typed, instead of restoring that key.
 
 Multiple options can be used at once. As an exception, regex and visual are mutually exclusive.
 

--- a/README.md
+++ b/README.md
@@ -197,6 +197,7 @@ Snippets can be edited in the plugin settings. The structure of a snippet is as 
 - `v` : [Visual](./DOCS.md#visual-snippets). Only run this snippet on a selection. The trigger should be a single character
 - `w` : Word boundary. Only run this snippet when the trigger is preceded (and followed by) a word delimiter, such as `.`, `,`, or `-`.
 - `c` : Code mode. Only run this snippet inside a ```` ``` ... ``` ```` block
+- `U`: Skip undo. When an automatic snippet expands, pressing undo returns to the state before the trigger key was typed, instead of first removing the snippet and reinserting that key.
 
 Insert **tabstops** for the cursor to jump to by writing "$0", "$1", etc. in the `replacement`.
 

--- a/src/default_snippets.js
+++ b/src/default_snippets.js
@@ -220,6 +220,10 @@ export default [
 	{trigger: "\\\\(${GREEK}) tilde", replacement: "\\tilde{\\[[0]]}", options: "rmA"},
 	{trigger: "\\\\(${GREEK}) und", replacement: "\\underline{\\[[0]]}", options: "rmA"},
 
+	// Disable automatic snippets while typing macros
+	// This is a catch all rule that may disable other snippets in some cases.
+	// Increase the priority of the snippets that shouldn't be disabled.
+	{trigger: /\\[A-Za-z]+/, replacement: "$0", options: "mAU", priority: 1, description: "Disable snippets while typing macros"},
 
     // Derivatives and integrals
     {trigger: "par", replacement: "\\frac{ \\partial ${0:y} }{ \\partial ${1:x} } $2", options: "m"},

--- a/src/default_snippets.js
+++ b/src/default_snippets.js
@@ -209,7 +209,21 @@ export default [
 	{trigger: "([^\\\\])(${SYMBOL})", replacement: "[[0]]\\[[1]]", options: "rmA", description: "Add backslash before symbols"},
 
     // Insert space after Greek letters and symbols
-	{trigger: "\\\\(${GREEK}|${SYMBOL}|${MORE_SYMBOLS})([A-Za-z])", replacement: "\\[[0]] [[1]]", options: "rmA"},
+	{
+		trigger: "\\\\(${GREEK}|${SYMBOL}|${MORE_SYMBOLS})([A-Za-z])",
+		replacement: function (match) {
+			const [string, trigger, letter] = match;
+			const new_trigger = new RegExp(this.trigger.source.replace("([A-Za-z])", "")); 
+			if (new_trigger.test(string)) {
+				return string;
+			} else {
+				return "\\" + trigger + " " + letter;
+			}
+		},
+		options: "rmA",
+		priority: 2
+	},
+
 	{trigger: "\\\\(${GREEK}|${SYMBOL}) sr", replacement: "\\[[0]]^{2}", options: "rmA"},
 	{trigger: "\\\\(${GREEK}|${SYMBOL}) cb", replacement: "\\[[0]]^{3}", options: "rmA"},
 	{trigger: "\\\\(${GREEK}|${SYMBOL}) rd", replacement: "\\[[0]]^{$0}$1", options: "rmA"},
@@ -220,10 +234,6 @@ export default [
 	{trigger: "\\\\(${GREEK}) tilde", replacement: "\\tilde{\\[[0]]}", options: "rmA"},
 	{trigger: "\\\\(${GREEK}) und", replacement: "\\underline{\\[[0]]}", options: "rmA"},
 
-	// Disable automatic snippets while typing macros
-	// This is a catch all rule that may disable other snippets in some cases.
-	// Increase the priority of the snippets that shouldn't be disabled.
-	{trigger: /\\[A-Za-z]+/, replacement: "$0", options: "mAU", priority: 1, description: "Disable snippets while typing macros"},
 
     // Derivatives and integrals
     {trigger: "par", replacement: "\\frac{ \\partial ${0:y} }{ \\partial ${1:x} } $2", options: "m"},
@@ -348,6 +358,29 @@ export default [
     // {trigger: /([A-Za-z]=\d+)([\n\s.,?!:'])/, replacement: "$[[0]]$[[1]]", options: "rtAw"},
     // {trigger: /([A-Za-z]=[A-Za-z][+-]\d+)([\n\s.,?!:'])/, replacement: "$[[0]]$[[1]]", options: "tAw"},
 
+	// Disable automatic snippets while typing macros
+	// This is a catch all rule that may disable other snippets in some cases.
+	// Increase the priority of the snippets that shouldn't be disabled.
+	// {trigger: /\\[A-Za-z]+/, replacement: "$0", options: "mAU", priority: 1, description: "Disable snippets while typing macros"},
+	// Less aggressive version of the above
+	{
+		trigger: /\\([A-Za-z]+)(?:${GREEK}|${SYMBOL}|${MORE_SYMBOLS}){0}/,
+		replacement: function (match) {
+			/** @type {string} */
+			const [string, trigger, letter] = match;
+			const test_string = this.trigger.source.replace("\\\\([A-Za-z]+)", "");
+			// Check if we are partways of a trigger
+			const new_trigger = new RegExp(`\\b${trigger}`); 
+			if (new_trigger.test(test_string)) {
+				return string;
+			} else {
+				return false
+			}
+		},
+		options: "mAU",
+		priority: 3,
+		description: "Disable snippets while typing macros",
+	},
 
     // Snippet replacements can have placeholders.
 	{trigger: "tayl", replacement: "${0:f}(${1:x} + ${2:h}) = ${0:f}(${1:x}) + ${0:f}'(${1:x})${2:h} + ${0:f}''(${1:x}) \\frac{${2:h}^{2}}{2!} + \\dots$3", options: "mA", description: "Taylor expansion"},
@@ -382,3 +415,8 @@ export default [
 		description: "Display math when in a list"
 	},
 ]
+
+const GREEK= "(?:alpha|beta|gamma|Gamma|delta|Delta|epsilon|varepsilon|zeta|eta|theta|vartheta|Theta|iota|kappa|lambda|Lambda|mu|nu|xi|omicron|pi|rho|varrho|sigma|Sigma|tau|upsilon|Upsilon|phi|varphi|Phi|chi|psi|omega|Omega)"
+const SYMBOL= "(?:parallel|perp|partial|nabla|hbar|ell|infty|oplus|ominus|otimes|oslash|square|star|dagger|vee|wedge|subseteq|subset|supseteq|supset|emptyset|exists|nexists|forall|implies|impliedby|iff|setminus|neg|lor|land|bigcup|bigcap|cdot|times|simeq|approx)"
+const MORE_SYMBOLS= "(?:leq|geq|neq|gg|ll|equiv|sim|propto|rightarrow|leftarrow|Rightarrow|Leftarrow|leftrightarrow|to|mapsto|cap|cup|in|sum|prod|exp|ln|log|det|dots|vdots|ddots|pm|mp|int|iint|iiint|oint)"
+const ACCENT= "(?:dot|ddot|hat|bar|tilde|vec|underline|overline|mathbf|mathcal|mathrm|mathbb)"

--- a/src/default_snippets.js
+++ b/src/default_snippets.js
@@ -214,6 +214,7 @@ export default [
 		replacement: function (match) {
 			const [string, trigger, letter] = match;
 			const new_trigger = new RegExp(this.trigger.source.replace("([A-Za-z])", "")); 
+			// Dont insert space when the current symbol is part of another symbol
 			if (new_trigger.test(string)) {
 				return string;
 			} else {

--- a/src/features/run_snippets.ts
+++ b/src/features/run_snippets.ts
@@ -96,7 +96,10 @@ const runSnippetCursor = (view: EditorView, ctx: Context, snippetInfo: SnippetIn
 
 		// Expand the snippet
 		const start = triggerPos;
-		const triggerKey = (snippet.options.automatic && snippet.type !== "visual") ? key : undefined;
+		const triggerKey =
+			snippet.options.automatic && snippet.type !== "visual" && snippet.options.undoKey
+				? key
+				: undefined;
 		queueSnippet(view, start, to, replacement, triggerKey);
 
 		const containsTrigger = settings.autoEnlargeBracketsTriggers.some(word => replacement.contains(word));

--- a/src/features/run_snippets.ts
+++ b/src/features/run_snippets.ts
@@ -110,7 +110,7 @@ const runSnippetCursor = (view: EditorView, ctx: Context, snippetInfo: SnippetIn
 			snippet.options.automatic && snippet.type !== "visual" && snippet.options.undoKey
 				? key
 				: undefined;
-		queueSnippet(view, start, triggerEndPos, replacement, triggerKey);
+		queueSnippet(view, start, triggerEndPos, replacement, triggerKey, to);
 
 		const containsTrigger = settings.autoEnlargeBracketsTriggers.some(word => replacement.contains(word));
 		if (debug === "info" || debug === "verbose") {

--- a/src/features/run_snippets.ts
+++ b/src/features/run_snippets.ts
@@ -106,8 +106,11 @@ const runSnippetCursor = (view: EditorView, ctx: Context, snippetInfo: SnippetIn
 
 		// Expand the snippet
 		const start = triggerPos;
-		const triggerKey = (snippet.options.automatic && snippet.type !== "visual") ? key : undefined;
-		queueSnippet(view, start, triggerEndPos, replacement, triggerKey, to);
+		const triggerKey =
+			snippet.options.automatic && snippet.type !== "visual" && snippet.options.undoKey
+				? key
+				: undefined;
+		queueSnippet(view, start, triggerEndPos, replacement, triggerKey);
 
 		const containsTrigger = settings.autoEnlargeBracketsTriggers.some(word => replacement.contains(word));
 		if (debug === "info" || debug === "verbose") {

--- a/src/snippets/options.ts
+++ b/src/snippets/options.ts
@@ -4,6 +4,7 @@ export class Options {
 	regex: boolean;
 	onWordBoundary: boolean;
 	visual: boolean;
+	undoKey: boolean;
 
 	constructor() {
 		this.mode = new Mode();
@@ -11,6 +12,7 @@ export class Options {
 		this.regex = false;
 		this.onWordBoundary = false;
 		this.visual = false;
+		this.undoKey = true;
 	}
 
 	static fromSource(source: string, language: string | undefined):Options {
@@ -31,6 +33,9 @@ export class Options {
 				case "v":
 					options.visual = true;
 					break;
+				case "U":
+					options.undoKey = false;
+				break;
 			}
 		}
 

--- a/src/snippets/snippets.ts
+++ b/src/snippets/snippets.ts
@@ -32,11 +32,11 @@ export type SnippetData<T extends SnippetType> = {
 	};
 	regex: {
 		trigger: RegExp;
-		replacement: string | ((match: RegExpExecArray) => string);
+		replacement: string | ((match: RegExpExecArray) => string | false);
 	};
 	string: {
 		trigger: string;
-		replacement: string | ((match: string) => string);
+		replacement: string | ((match: string) => string | false);
 	};
 }[T]
 

--- a/src/snippets/snippets.ts
+++ b/src/snippets/snippets.ts
@@ -32,12 +32,12 @@ export type SnippetData<T extends SnippetType> = {
 	};
 	regex: {
 		trigger: RegExp;
-		replacement: string | ((match: RegExpExecArray) => string);
+		replacement: string | ((match: RegExpExecArray) => string | false);
 		triggerAfter?: RegExp;
 	};
 	string: {
 		trigger: string;
-		replacement: string | ((match: string) => string);
+		replacement: string | ((match: string) => string | false);
 		triggerAfter?: string;
 	};
 }[T]


### PR DESCRIPTION
Fixes #186

Adds the ability for each snippet to insert the key thus undoing the snippet and possibly the trigger.

Somewhat helps #68 #201 #328  #440 #389 #426 #396 #342 but not fully so not closing them.