### PR TITLE
feat: better sourcemapping for import snippets

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -33,7 +33,6 @@
 				"esbuild-plugin-inline-import": "^1.0.2",
 				"eslint": "^9.39.2",
 				"globals": "^17.3.0",
-				"js-base64": "^3.7.5",
 				"obsidian": "^0.15.0",
 				"tslib": "2.3.1",
 				"typescript": "^5.9.3"
@@ -1678,12 +1677,6 @@
 			"dev": true,
 			"license": "ISC"
 		},
-		"node_modules/js-base64": {
-			"version": "3.7.5",
-			"resolved": "https://registry.npmjs.org/js-base64/-/js-base64-3.7.5.tgz",
-			"integrity": "sha512-3MEt5DTINKqfScXKfJFrRbxkrnk2AxPWGBL/ycjz4dK8iqiSJ06UxD8jh8xuh6p10TX4t2+7FsBYVxxQbMg+qA==",
-			"dev": true
-		},
 		"node_modules/js-yaml": {
 			"version": "4.1.1",
 			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
@@ -3136,12 +3129,6 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
 			"integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
-			"dev": true
-		},
-		"js-base64": {
-			"version": "3.7.5",
-			"resolved": "https://registry.npmjs.org/js-base64/-/js-base64-3.7.5.tgz",
-			"integrity": "sha512-3MEt5DTINKqfScXKfJFrRbxkrnk2AxPWGBL/ycjz4dK8iqiSJ06UxD8jh8xuh6p10TX4t2+7FsBYVxxQbMg+qA==",
 			"dev": true
 		},
 		"js-yaml": {

--- a/package.json
+++ b/package.json
@@ -36,7 +36,6 @@
 		"esbuild-plugin-inline-import": "^1.0.2",
 		"eslint": "^9.39.2",
 		"globals": "^17.3.0",
-		"js-base64": "^3.7.5",
 		"obsidian": "^0.15.0",
 		"tslib": "2.3.1",
 		"typescript": "^5.9.3"

--- a/src/main.ts
+++ b/src/main.ts
@@ -116,7 +116,7 @@ export default class LatexSuitePlugin extends Plugin {
 
 	async getSettingsSnippetVariables() {
 		try {
-			return await parseSnippetVariables(this.settings.snippetVariables);
+			return await parseSnippetVariables(this.settings.snippetVariables, "snippet-variables.js");
 		} catch (e) {
 			new Notice(`Failed to load snippet variables from settings: ${e}`);
 			console.error(`Failed to load snippet variables from settings: ${e}`);
@@ -126,7 +126,7 @@ export default class LatexSuitePlugin extends Plugin {
 
 	async getSettingsSnippets(snippetVariables: SnippetVariables) {
 		try {
-			return await parseSnippets(this.settings.snippets, snippetVariables);
+			return await parseSnippets(this.settings.snippets, snippetVariables, "snippets.js");
 		} catch (e) {
 			new Notice(`Failed to load snippets from settings: ${e}`);
 			console.error(`Failed to load snippets from settings: ${e}`);

--- a/src/settings/file_watch.ts
+++ b/src/settings/file_watch.ts
@@ -120,7 +120,7 @@ export async function getVariablesFromFiles(plugin: LatexSuitePlugin, files: Fil
 	for (const file of files.definitelyVariableFiles) {
 		const content = await plugin.app.vault.cachedRead(file);
 		try {
-			Object.assign(snippetVariables, await parseSnippetVariables(content));
+			Object.assign(snippetVariables, await parseSnippetVariables(content, file.toString()));
 		} catch (e) {
 			new Notice(`Failed to parse variable file ${file.name}: ${e}`);
 			console.error(`Failed to parse variable file ${file.name}: ${e}`);
@@ -137,7 +137,7 @@ export async function tryGetVariablesFromUnknownFiles(plugin: LatexSuitePlugin, 
 	for (const file of files.snippetOrVariableFiles) {
 		const content = await plugin.app.vault.cachedRead(file);
 		try {
-			Object.assign(snippetVariables, await parseSnippetVariables(content));
+			Object.assign(snippetVariables, await parseSnippetVariables(content, file.toString()));
 			files.definitelyVariableFiles.add(file);
 		} catch {
 			// No error here, we just assume this is a snippets file.
@@ -160,7 +160,7 @@ export async function getSnippetsFromFiles(
 	for (const file of files.definitelySnippetFiles) {
 		const content = await plugin.app.vault.cachedRead(file);
 		try {
-			snippets.push(...await parseSnippets(content, snippetVariables));
+			snippets.push(...await parseSnippets(content, snippetVariables, file.toString()));
 		} catch (e) {
 			new Notice(`Failed to parse snippet file ${file.name}: ${e}`);
 			console.error(`Failed to parse snippet file ${file.name}: ${e}`);

--- a/src/settings/settings_tab.ts
+++ b/src/settings/settings_tab.ts
@@ -733,8 +733,8 @@ export class LatexSuiteSettingTab extends PluginSettingTab {
 
 				let snippetVariables;
 				try {
-					snippetVariables = await parseSnippetVariables(this.plugin.settings.snippetVariables)
-					await parseSnippets(snippets, snippetVariables);
+					snippetVariables = await parseSnippetVariables(this.plugin.settings.snippetVariables, "snippet-variables.js");
+					await parseSnippets(snippets, snippetVariables, "snippets.js");
 				}
 				catch {
 					success = false;

--- a/src/snippets/parse.ts
+++ b/src/snippets/parse.ts
@@ -1,5 +1,4 @@
 import { optional, object, string as string_, union, instance, parse, number, Output, special } from "valibot";
-import { encode } from "js-base64";
 import { RegexSnippet, serializeSnippetLike, Snippet, StringSnippet, VISUAL_SNIPPET_MAGIC_SELECTION_PLACEHOLDER, VisualSnippet } from "./snippets";
 import { Options } from "./options";
 import { sortSnippets } from "./sort";
@@ -8,25 +7,37 @@ import { Platform } from "obsidian";
 
 export type SnippetVariables = Record<string, string>;
 
-async function importRaw(maybeJavaScriptCode: string) {
-	let raw;
-	try {
-		try {
-			// first, try to import as a plain js module
-			// js-base64.encode is needed over builtin `window.btoa` because the latter errors on unicode
-			raw = await importModuleDefault(`data:text/javascript;base64,${encode(maybeJavaScriptCode)}`);
-		} catch {
-			// otherwise, try to import as a standalone js object
-			raw = await importModuleDefault(`data:text/javascript;base64,${encode(`export default ${maybeJavaScriptCode}`)}`);
-		}
-	} catch {
-		throw "Invalid format";
-	}
-	return raw;
+function importModule(source: string, identifier: string): Promise<object> {
+	const sourceWithSourceURL = `${source}\n//# sourceURL=latex-suite:${identifier}`;
+	const blob = new Blob([sourceWithSourceURL], { type: "text/javascript" });
+	const url = URL.createObjectURL(blob);
+	const result = import(url);
+	URL.revokeObjectURL(url);
+	return result;
 }
 
-export async function parseSnippetVariables(snippetVariablesStr: string) {
-	const rawSnippetVariables = await importRaw(snippetVariablesStr) as SnippetVariables;
+async function importRaw(module: string, identifier: string): Promise<unknown> {
+	let data: object;
+	try {
+		data = await importModule(module, identifier);
+	} catch (e) {
+		console.error(e)
+		try {
+		data = await importModule("export default " + module, identifier);
+		} catch (e) {
+			console.error(e)
+			throw "Invalid format";
+		}
+	}
+	if ("default" in data) {
+		return data.default;
+	} else {
+		throw "No default export found";
+	}
+}
+
+export async function parseSnippetVariables(snippetVariablesStr: string, identifier: string) {
+	const rawSnippetVariables = await importRaw(snippetVariablesStr, identifier) as SnippetVariables;
 
 	if (Array.isArray(rawSnippetVariables))
 		throw "Cannot parse an array as a variables object";
@@ -48,8 +59,8 @@ export async function parseSnippetVariables(snippetVariablesStr: string) {
 	return snippetVariables;
 }
 
-export async function parseSnippets(snippetsStr: string, snippetVariables: SnippetVariables) {
-	const rawSnippets = await importRaw(snippetsStr);
+export async function parseSnippets(snippetsStr: string, snippetVariables: SnippetVariables, identifier: string) {
+	const rawSnippets = await importRaw(snippetsStr, identifier);
 
 	let parsedSnippets;
 	try {
@@ -72,32 +83,6 @@ export async function parseSnippets(snippetsStr: string, snippetVariables: Snipp
 	parsedSnippets = sortSnippets(parsedSnippets);
 
 	return parsedSnippets;
-}
-
-/** load snippet string as module */
-
-/**
- * imports the default export of a given module.
- *
- * @param module the module to import. this can be a resource path, data url, etc
- * @returns the default export of said module
- * @throws if import fails or default export is undefined
- */
-async function importModuleDefault(module: string): Promise<unknown> {
-	let data;
-	try {
-		data = await import(module);
-	} catch {
-		throw `failed to import module ${module}`;
-	}
-
-	// it's safe to use `in` here - it has a null prototype, so `Object.hasOwnProperty` isn't available,
-	// but on the other hand we don't need to worry about something further up the prototype chain messing with this check
-	if (!("default" in data)) {
-		throw `No default export provided for module ${module}`;
-	}
-
-	return data.default;
 }
 
 /** raw snippet IR */


### PR DESCRIPTION
Using sourceURL=name to refer to the correct file when console.log or when there is an syntax error inside the file. And using a blob instead of using encode from js-base64 removing a dependency.