### PR TITLE
exp: add support for IME by running automatic snippets after an update instead before

### DIFF
--- a/src/editor_extensions/conceal.ts
+++ b/src/editor_extensions/conceal.ts
@@ -5,6 +5,7 @@ import { EditorSelection, Range, RangeSet, RangeSetBuilder, RangeValue } from "@
 import { conceal, ConcealCachedEquations } from "./conceal_fns";
 import { debounce, livePreviewState } from "obsidian";
 import { getLatexSuiteConfig } from "src/snippets/codemirror/config";
+import { tempKeyPress } from "src/snippets/snippet_management";
 
 export type Replacement = {
 	start: number,
@@ -292,6 +293,9 @@ export const concealPlugin = ViewPlugin.fromClass(class {
 	update(update: ViewUpdate) {
 		if (!(update.docChanged || update.viewportChanged || update.selectionSet))
 			return;
+		if (update.transactions.some(tr => tr.annotation(tempKeyPress))) {
+			return;
+		}
 
 		// Cancel the delayed revealment whenever we update the concealments
 		this.delayedReveal.cancel();

--- a/src/editor_extensions/highlight_brackets.ts
+++ b/src/editor_extensions/highlight_brackets.ts
@@ -2,6 +2,7 @@ import { EditorView, ViewUpdate, Decoration, DecorationSet, ViewPlugin } from "@
 import { Prec, Range } from "@codemirror/state";
 import { findMatchingBracket, getOpenBracket, getCloseBracket } from "../utils/editor_utils";
 import { Context, getContextPlugin, getMathBoundsPlugin } from "src/utils/context";
+import { tempKeyPress } from "src/snippets/snippet_management";
 
 const Ncolors = 3;
 
@@ -198,6 +199,9 @@ export const colorPairedBracketsPlugin = ViewPlugin.fromClass(class {
 	}
 
 	update(update: ViewUpdate) {
+		if (update.transactions.some(tr => tr.annotation(tempKeyPress))) {
+			return;
+		}
 		if (update.docChanged || update.viewportChanged) {
 			({
 				decorations: this.decorations,
@@ -219,6 +223,9 @@ export const highlightCursorBracketsPlugin = ViewPlugin.fromClass(class {
 	}
 
 	update(update: ViewUpdate) {
+		if (update.transactions.some(tr => tr.annotation(tempKeyPress))) {
+			return;
+		}
 		if (update.docChanged || update.selectionSet)
 			this.decorations = highlightCursorBrackets(update.view);
 	}

--- a/src/latex_suite.ts
+++ b/src/latex_suite.ts
@@ -6,7 +6,7 @@ import { addCellMatrixShortcut, exitMatrixShortCut, newlineMatrixShortcut, prior
 
 import { getContextPlugin } from "./utils/context";
 import { getCharacterAtPos, replaceRange } from "./utils/editor_utils";
-import { setSelectionToNextTabstop } from "./snippets/snippet_management";
+import { setSelectionToNextTabstop, tempKeyPress } from "./snippets/snippet_management";
 import { removeAllTabstops } from "./snippets/codemirror/tabstops_state_field";
 import { getLatexSuiteConfig } from "./snippets/codemirror/config";
 import { clearSnippetQueue } from "./snippets/codemirror/snippet_queue_state_field";
@@ -21,11 +21,25 @@ export const handleUpdate = (update: ViewUpdate) => {
 
 	// The math tooltip handler is driven by view updates because it utilizes
 	// information about visual line, which is not available in EditorState
-	if (settings.mathPreviewEnabled) {
+	if (settings.mathPreviewEnabled && !update.transactions.some(tr => tr.annotation(tempKeyPress))) {
 		handleMathTooltip(update);
 	}
 
-	handleUndoRedo(update);
+	if (handleUndoRedo(update)) {
+		return;
+	}
+
+	const isUserEvent = update.transactions.some((tr) => tr.isUserEvent("input"));
+	if (!isUserEvent) {
+		return;
+	}
+
+	// HACK: reusing logic from handleKeydown with empty string
+	const success = handleKeydown("", false, update.view.composing, update.view);
+	if (success) {
+		forceEndComposition(update.view);
+	}
+
 }
 
 export const keyboardEventPlugin = ViewPlugin.fromClass(class {
@@ -38,8 +52,17 @@ export const keyboardEventPlugin = ViewPlugin.fromClass(class {
 		} else {
 			this.lastKeyboardEvent = null;
 		}
+		const snippetIMEVersion = getLatexSuiteConfig(view).snippetIMEVersion;
 
-		const success = handleKeydown(event.key, event.ctrlKey || event.metaKey, isComposing(view, event), view) || runScopeHandlers(view, event, "latex-suite");
+		const success =
+			(!snippetIMEVersion &&
+				handleKeydown(
+					event.key,
+					event.ctrlKey || event.metaKey,
+					isComposing(view, event),
+					view,
+				)) ||
+			runScopeHandlers(view, event, "latex-suite");
 
 		if (success) event.preventDefault();
 	}
@@ -53,6 +76,10 @@ export const keyboardEventPlugin = ViewPlugin.fromClass(class {
 })
 
 export const onInput = (view: EditorView, from: number, to: number, text: string): boolean => {
+	const snippetIMEVersion = getLatexSuiteConfig(view).snippetIMEVersion;
+	if (snippetIMEVersion) {
+		return false;
+	}
 	const lastKeyboardEvent = view.plugin(keyboardEventPlugin)?.lastKeyboardEvent;
 	if (text === "\0\0") return true;
 	if (text.length == 1 && lastKeyboardEvent) {

--- a/src/settings/settings.ts
+++ b/src/settings/settings.ts
@@ -39,6 +39,7 @@ interface LatexSuiteBasicSettings {
 	vimVisualMode: VimKeyMap;
 	vimMatrixEnter: VimKeyMap;
 	snippetRecursion: number;
+	snippetIMEVersion: boolean;
 
 }
 
@@ -122,6 +123,7 @@ export const DEFAULT_SETTINGS: LatexSuitePluginSettings = {
 	vimVisualMode: "<C-g>",
 	vimMatrixEnter: "o",
 	snippetRecursion: 0,
+	snippetIMEVersion: false,
 }
 
 export function processLatexSuiteSettings(snippets: Snippet[], settings: LatexSuitePluginSettings):LatexSuiteCMSettings {

--- a/src/settings/settings_tab.ts
+++ b/src/settings/settings_tab.ts
@@ -700,6 +700,17 @@ export class LatexSuiteSettingTab extends PluginSettingTab {
 					await this.plugin.saveSettings();
 				})
 			);
+		
+		new Setting(containerEl)
+			.setName("IME support for automatic snippets")
+			.setDesc("Whether to expand automatic snippets when a key is pressed after IME composition instead of during IME composition. This may solve some issues with IME/Chinese keyboards. Will force end composition after a successful snippet expansion.")
+			.addToggle((toggle) => toggle
+				.setValue(this.plugin.settings.snippetIMEVersion)
+				.onChange(async (value) => {
+					this.plugin.settings.snippetIMEVersion = value;
+					await this.plugin.saveSettings();
+				})
+			);
 	}
 
 	createSnippetsEditor(snippetsSetting: Setting) {

--- a/src/snippets/codemirror/history.ts
+++ b/src/snippets/codemirror/history.ts
@@ -54,4 +54,5 @@ export const handleUndoRedo = (update: ViewUpdate) => {
 	if (undoTr) {
 		removeAllTabstops(update.view);
 	}
+	return !!(undoTr || redoTr);
 };

--- a/src/snippets/snippet_management.ts
+++ b/src/snippets/snippet_management.ts
@@ -1,5 +1,5 @@
 import { EditorView } from "@codemirror/view";
-import { ChangeSet, EditorSelection } from "@codemirror/state";
+import { Annotation, ChangeSet, EditorSelection } from "@codemirror/state";
 import { endSnippet, startSnippet } from "./codemirror/history";
 import { isolateHistory } from "@codemirror/commands";
 import { TabstopSpec, tabstopSpecsToTabstopGroups } from "./tabstop";
@@ -37,6 +37,8 @@ export function expandSnippets(view: EditorView):boolean {
 	clearSnippetQueue(view);
 	return true;
 }
+// optimization to avoid updating math preview and conceal when a keypress is pushed into the history but immediately undone
+export const tempKeyPress = Annotation.define<true>();
 
 function handleUndoKeypresses(view: EditorView, snippets: SnippetChangeSpec[]) {
 	const originalDoc = view.state.doc;
@@ -59,7 +61,7 @@ function handleUndoKeypresses(view: EditorView, snippets: SnippetChangeSpec[]) {
 	if (keyPresses.length > 0) {
 		view.dispatch({
 			changes: keyPresses,
-			annotations: isolateHistory.of("full"),
+			annotations: [isolateHistory.of("full"), tempKeyPress.of(true)],
 		});
 	}
 
@@ -122,7 +124,8 @@ function expandTabstops(
 	view.dispatch({
 		effects: [...effects, startSnippet.of(extraTabstopGroups)],
 		changes: undoChanges.changes.compose(changes),
-		selection: undoChanges.selection
+		selection: undoChanges.selection,
+		annotations: isolateHistory.of("before")
 	}, spec);
 }
 


### PR DESCRIPTION
Before trying to insert the complex logic that codemirror uses to reconstruct IME compositions, just use the update logic to get the composition. Might reconstruct if this is succesful but has some niche issues thats causes by handeling the snippet expansion after instead of before.

Hopefully fixes #334 but keeping it open cause experimental