### PR TITLE
refactor: only slice the range thats needed and not the whole document

### DIFF
--- a/src/editor_extensions/highlight_brackets.ts
+++ b/src/editor_extensions/highlight_brackets.ts
@@ -118,26 +118,27 @@ function highlightCursorBrackets(view: EditorView) {
 	const widgets: Range<Decoration>[] = []
 	const selection = view.state.selection;
 	const ranges = selection.ranges;
-	const text = view.state.doc.toString();
 	const ctx = getContextPlugin(view);
 
 	if (!ctx.mode.inMath()) {
 		return Decoration.none;
 	}
 
-	const bounds = ctx.getBounds(selection.main.to);
-	if (!bounds) return Decoration.none;
-	const eqn = view.state.doc.sliceString(bounds.inner_start, bounds.inner_end);
-
 	const openBrackets = ["{", "[", "("];
 	const brackets = ["{", "[", "(", "}", "]", ")"];
 
-	let done = false;
-
-	for (const range of ranges) {
-
+	outer_loop: for (const range of ranges) {
+		const bounds = ctx.getBounds(range.to);
+		if (!bounds) {
+			console.log("No bounds found for position", range.to);
+			continue;
+		}
+		const eqn = view.state.doc.sliceString(
+			bounds.inner_start,
+			bounds.inner_end,
+		);
 		for (let i = range.to; i > range.from - 2; i--) {
-			const char = text.charAt(i);
+			const char = eqn.charAt(i - bounds.inner_start);
 			if (!brackets.contains(char)) continue;
 
 			let openBracket, closeBracket;
@@ -161,11 +162,8 @@ function highlightCursorBrackets(view: EditorView) {
 
 			widgets.push(getHighlightBracketMark(i, "latex-suite-highlighted-bracket"));
 			widgets.push(getHighlightBracketMark(j, "latex-suite-highlighted-bracket"));
-			done = true;
-			break;
+			continue outer_loop;
 		}
-
-		if (done) break;
 
 		// Highlight brackets enclosing the cursor
 		if (range.empty) {
@@ -176,11 +174,7 @@ function highlightCursorBrackets(view: EditorView) {
 
 			widgets.push(getHighlightBracketMark(result.left, "latex-suite-highlighted-bracket"));
 			widgets.push(getHighlightBracketMark(result.right, "latex-suite-highlighted-bracket"));
-			done = true;
-			break;
 		}
-
-		if (done) break;
 	}
 
 	return Decoration.set(widgets, true);

--- a/src/features/autofraction.ts
+++ b/src/features/autofraction.ts
@@ -24,6 +24,9 @@ export const runAutoFraction = (view: EditorView, ctx: Context): boolean => {
 }
 
 
+const greek = "alpha|beta|gamma|Gamma|delta|Delta|epsilon|varepsilon|zeta|eta|theta|Theta|iota|kappa|lambda|Lambda|mu|nu|omicron|xi|Xi|pi|Pi|rho|sigma|Sigma|tau|upsilon|Upsilon|varphi|phi|Phi|chi|psi|Psi|omega|Omega";
+const regex = new RegExp("(" + greek + ") ([^ ])", "g");
+
 export const runAutoFractionCursor = (view: EditorView, ctx: Context, range: SelectionRange):boolean => {
 
 	const settings = getLatexSuiteConfig(view);
@@ -42,7 +45,7 @@ export const runAutoFractionCursor = (view: EditorView, ctx: Context, range: Sel
 	const eqnStart = result.inner_start;
 
 
-	let curLine = view.state.sliceDoc(0, to);
+	let curLine = view.state.sliceDoc(eqnStart, to);
 	let start = eqnStart;
 
 	if (from != to) {
@@ -57,13 +60,11 @@ export const runAutoFractionCursor = (view: EditorView, ctx: Context, range: Sel
 
 		// Also, allow spaces after greek letters
 		// By replacing spaces after greek letters with a dummy character (#)
-
-		const greek = "alpha|beta|gamma|Gamma|delta|Delta|epsilon|varepsilon|zeta|eta|theta|Theta|iota|kappa|lambda|Lambda|mu|nu|omicron|xi|Xi|pi|Pi|rho|sigma|Sigma|tau|upsilon|Upsilon|varphi|phi|Phi|chi|psi|Psi|omega|Omega";
-		const regex = new RegExp("(" + greek + ") ([^ ])", "g");
+		regex.lastIndex = 0;
 		curLine = curLine.replace(regex, "$1#$2");
 
 
-		for (let i = curLine.length - 1; i >= eqnStart; i--) {
+		for (let i = curLine.length - 1; i >= 0; i--) {
 			const curChar = curLine.charAt(i)
 
 			if ([")", "]", "}"].contains(curChar)) {
@@ -76,17 +77,11 @@ export const runAutoFractionCursor = (view: EditorView, ctx: Context, range: Sel
 
 				// Skip to the beginnning of the bracket
 				i = j;
-
-				if (i < eqnStart) {
-					start = eqnStart;
-					break;
-				}
-
 			}
 
 
 			if (" $([{\n".concat(settings.autofractionBreakingChars).contains(curChar)) {
-				start = i+1;
+				start = i + 1 + eqnStart;
 				break;
 			}
 		}

--- a/src/snippets/codemirror/snippet_change_spec.ts
+++ b/src/snippets/codemirror/snippet_change_spec.ts
@@ -1,4 +1,4 @@
-import { ChangeSpec } from "@codemirror/state"
+import { ChangeSpec, Text } from "@codemirror/state"
 import { TabstopSpec } from "../tabstop";
 import { findMatchingBracket } from "src/utils/editor_utils";
 
@@ -15,10 +15,10 @@ export class SnippetChangeSpec {
         this.keyPressed = keyPressed;
     }
 
-    getTabstops(text: string, start: number):TabstopSpec[] {
+    getTabstops(doc: Text, start: number):TabstopSpec[] {
         const tabstops:TabstopSpec[] = [];
-
-        for (let i = start; i < start + this.insert.length; i++) {
+		const text = doc.sliceString(start, start + this.insert.length);
+        for (let i = 0; i < text.length; i++) {
 
             if (!(text.charAt(i) === "$")) {
                 continue;
@@ -63,7 +63,12 @@ export class SnippetChangeSpec {
             }
     
             // Replace the tabstop indicator "$X" with ""
-            const tabstop = {number: number, from: tabstopStart, to: tabstopEnd, replacement: tabstopReplacement};
+            const tabstop = {
+				number: number,
+				from: tabstopStart + start,
+				to: tabstopEnd + start,
+				replacement: tabstopReplacement,
+			};
             tabstops.push(tabstop);
         }
 

--- a/src/snippets/snippet_management.ts
+++ b/src/snippets/snippet_management.ts
@@ -7,6 +7,7 @@ import { addTabstops, getNextTabstopColor, tabstopsStateField } from "./codemirr
 import { clearSnippetQueue, getSnippetQueue } from "./codemirror/snippet_queue_state_field";
 import { SnippetChangeSpec } from "./codemirror/snippet_change_spec";
 import { resetCursorBlink } from "src/utils/editor_utils";
+import { Text } from "@codemirror/state";
 
 export function expandSnippets(view: EditorView):boolean {
 	const snippetsToExpand = getSnippetQueue(view).snippetQueueValue;
@@ -18,7 +19,7 @@ export function expandSnippets(view: EditorView):boolean {
 	const undoChanges = handleUndoKeypresses(view, snippetsToExpand);
 	// If from===to, normally the cursor would be before the text, but after the text makes more sense as that happens when from <to.
 	const selection = view.state.selection.map(undoChanges, 1);
-	const newText = undoChanges.apply(view.state.doc).toString();
+	const newText = undoChanges.apply(view.state.doc);
 	const tabstopsToAdd = computeTabstops(newText, snippetsToExpand, originalDocLength);
 	const changes = {
 		changes: undoChanges,
@@ -74,15 +75,14 @@ function handleUndoKeypresses(view: EditorView, snippets: SnippetChangeSpec[]) {
 	return combinedChanges;
 }
 
-function computeTabstops(text: string, snippets: SnippetChangeSpec[], originalDocLength: number) {
+function computeTabstops(doc: Text, snippets: SnippetChangeSpec[], originalDocLength: number) {
 	// Find the positions of the cursors in the new document
 	const changeSet = ChangeSet.of(snippets, originalDocLength);
 	const oldPositions = snippets.map(change => change.from);
 	const newPositions = oldPositions.map(pos => changeSet.mapPos(pos));
-
 	const tabstopsToAdd:TabstopSpec[] = [];
 	for (let i = 0; i < snippets.length; i++) {
-		tabstopsToAdd.push(...snippets[i].getTabstops(text, newPositions[i]));
+		tabstopsToAdd.push(...snippets[i].getTabstops(doc, newPositions[i]));
 	}
 
 	return tabstopsToAdd;

--- a/src/utils/editor_utils.ts
+++ b/src/utils/editor_utils.ts
@@ -12,7 +12,7 @@ export function replaceRange(view: EditorView, start: number, end: number, repla
 export function getCharacterAtPos(viewOrState: EditorView | EditorState, pos: number) {
 	const state = viewOrState instanceof EditorView ? viewOrState.state : viewOrState;
 	const doc = state.doc;
-	return doc.slice(pos, pos+1).toString();
+	return doc.sliceString(pos, pos+1);
 }
 
 


### PR DESCRIPTION
Slight peformance enhancment which should cause less gc and memory usage but only slight as other things arleady have a large memory footprint that it will be hardly noticable.
It was more that a function shouldn't get more text than its working on. 
It does make bookkeeping of the indexes a bit more annoying, not sure what the best approach is.