### PR TITLE
fix: add hotreload back in for changing reveal timeout

### DIFF
--- a/src/editor_extensions/conceal.ts
+++ b/src/editor_extensions/conceal.ts
@@ -246,7 +246,7 @@ function buildAtomicRanges(concealments: Concealment[]) {
 	return builder.finish();
 }
 
-export const concealPlugin = ViewPlugin.fromClass(class {
+export const mkConcealPlugin = (revealTimeout: number) => ViewPlugin.fromClass(class {
 	// Stateful ViewPlugin: you should avoid one in general, but here
 	// the approach based on StateField and updateListener conflicts with
 	// obsidian's internal logic and causes weird rendering.
@@ -263,7 +263,6 @@ export const concealPlugin = ViewPlugin.fromClass(class {
 		this.concealments = [];
 		this.decorations = Decoration.none;
 		this.atomicRanges = RangeSet.empty;
-		const revealTimeout = getLatexSuiteConfig(view).concealRevealTimeout;
 		this.delayEnabled = revealTimeout > 0;
 		this.cached_equations = {};
 		this.concealSpecs = [];

--- a/src/main.ts
+++ b/src/main.ts
@@ -11,7 +11,7 @@ import { SnippetVariables, parseSnippetVariables, parseSnippets } from "./snippe
 import { handleUpdate, onInput, keyboardEventPlugin, getKeymaps } from "./latex_suite";
 import { EditorView, keymap, tooltips } from "@codemirror/view";
 import { snippetExtensions } from "./snippets/codemirror/extensions";
-import { concealPlugin } from "./editor_extensions/conceal";
+import { mkConcealPlugin } from "./editor_extensions/conceal";
 import { colorPairedBracketsPluginLowestPrec, highlightCursorBracketsPlugin } from "./editor_extensions/highlight_brackets";
 import { cursorTooltipBaseTheme, cursorTooltipField } from "./editor_extensions/math_tooltip";
 import { contextPlugin, mathBoundsPlugin } from "./utils/context";
@@ -191,7 +191,7 @@ export default class LatexSuitePlugin extends Plugin {
 
 		// Optional extensions
 		if (this.CMSettings.concealEnabled) {
-			this.editorExtensions.push(concealPlugin);
+			this.editorExtensions.push(mkConcealPlugin(this.settings.concealRevealTimeout));
 		}
 		if (this.CMSettings.colorPairedBracketsEnabled)
 			this.editorExtensions.push(colorPairedBracketsPluginLowestPrec);


### PR DESCRIPTION
Found in #549. 

The viewplugin evaluates the constructor once instead of when it gets inserted into the editor.