### PR TITLE
fix: selection tabstop number parsing

### DIFF
--- a/src/snippets/codemirror/snippet_change_spec.ts
+++ b/src/snippets/codemirror/snippet_change_spec.ts
@@ -26,18 +26,28 @@ export class SnippetChangeSpec {
                 continue;
             }
     
-            let number:number = parseInt(text.charAt(i + 1));
-    
-            const tabstopStart = i;
-            let tabstopEnd = tabstopStart + 2;
-            let tabstopReplacement = "";
-    
-    
-            if (isNaN(number)) {
+			if (/\d/.test(text.charAt(i+1))) {
+				const number:number = parseInt(text.charAt(i + 1));
+		
+				const tabstopStart = i;
+				const tabstopEnd = tabstopStart + 2;
+				const tabstopReplacement = "";
+
+				// Replace the tabstop indicator "$X" with ""
+				tabstops.push({
+					number,
+					from: tabstopStart + start,
+					to: tabstopEnd + start,
+					replacement: tabstopReplacement,
+				})
+				continue;
+
+			} else if (text.charAt(i+1) === "{") {
                 // Check for selection tabstops of the form ${\d+:XXX} where \d+ is some number of
                 // digits and XXX is the replacement string, separated by a colon
-                if (!(text.charAt(i+1) === "{")) continue;
-    
+				const tabstopStart = i;
+
+ 
                 // Find the index of the matching closing bracket
                 const closingIndex = findMatchingBracket(text, i+1, "{", "}", false, start + this.insert.length);
                 
@@ -52,26 +62,27 @@ export class SnippetChangeSpec {
     
                 // Parse the number from the tabstop string, which is all characters after the {
                 // and before the colon index
-                number = parseInt(tabstopString.slice(2, colonIndex));
-                if (isNaN(number)) continue;
-                
+				const rawTabstopNumber = tabstopString.slice(2, colonIndex);
+				if (!/^\d+$/.test(rawTabstopNumber)) continue;
+				const number: number = parseInt(rawTabstopNumber);
     
                 if (closingIndex === -1) continue;
     
                 // Isolate the replacement text from after the colon to the end of the tabstop bracket pair
-                tabstopReplacement = text.slice(i+colonIndex+1, closingIndex);
-                tabstopEnd = closingIndex + 1;
+                const tabstopReplacement = text.slice(i+colonIndex+1, closingIndex);
+                const tabstopEnd = closingIndex + 1;
                 i = closingIndex;
+				const tabstop = {
+					number: number,
+					from: tabstopStart + start,
+					to: tabstopEnd + start,
+					replacement: tabstopReplacement,
+				};
+				// Replace the tabstop indicator "${\d+:XXX}" with "XXX"
+				tabstops.push(tabstop);
+				continue
             }
     
-            // Replace the tabstop indicator "$X" with ""
-            const tabstop = {
-				number: number,
-				from: tabstopStart + start,
-				to: tabstopEnd + start,
-				replacement: tabstopReplacement,
-			};
-            tabstops.push(tabstop);
         }
 
         return tabstops;


### PR DESCRIPTION
Fixes #553.

Only parse selection tabstops of the pattern ${\d+:XXXX} instead of ${giberish number_format giberish:XXX} as parseInt only returns NaN if it can't find a number format instead of only allowing positive numbers for the whole string. Thus \d+ was tested first