### PR TITLE
[BUG] Find-string text box background color does not use obsidian's color scheme

### DIFF
--- a/src/settings/ui/snippets_editor/obsidian_theme.ts
+++ b/src/settings/ui/snippets_editor/obsidian_theme.ts
@@ -85,6 +85,15 @@ export const obsidianTheme = EditorView.theme({
 			color: config.foreground
 		}
 	},
+	".cm-textfield": {
+		backgroundColor: config.background,
+		color: config.foreground
+	},
+	".cm-button": {
+		backgroundColor: config.background,
+		color: config.foreground,
+		backgroundImage: "none",
+	}
 }, {dark: config.dark})
 
 export const obsidianHighlightStyle = HighlightStyle.define([


### PR DESCRIPTION
Fixes #236