### PR TITLE
New snippet; "deg" for degree symbol

### DIFF
--- a/src/default_snippets.js
+++ b/src/default_snippets.js
@@ -166,6 +166,7 @@ export default [
 	{trigger: "xx", replacement: "\\times", options: "mA"},
     {trigger: "**", replacement: "\\cdot", options: "mA"},
     {trigger: "para", replacement: "\\parallel", options: "mA"},
+	{trigger: "deg", replacement: "\\degree", options: "mA"},
 
 	{trigger: "===", replacement: "\\equiv", options: "mA"},
     {trigger: "!=", replacement: "\\neq", options: "mA"},
@@ -259,8 +260,6 @@ export default [
 
 
     // Trigonometry
-	{trigger: "deg", replacement: "°", options: "mA"}, // Degree symbol. The following trig snippets are linked to sine, cosine & tangent
-	
     {trigger: /([^\\])(arcsin|sin|arccos|cos|arctan|tan|csc|sec|cot)/, replacement: "[[0]]\\[[1]]", options: "rmA", description: "Add backslash before trig funcs"},
 
     {trigger: /\\(arcsin|sin|arccos|cos|arctan|tan|csc|sec|cot)([A-Za-gi-z])/,

--- a/src/default_snippets.js
+++ b/src/default_snippets.js
@@ -259,6 +259,8 @@ export default [
 
 
     // Trigonometry
+	{trigger: "deg", replacement: "°", options: "mA"}, // Degree symbol. The following trig snippets are linked to sine, cosine & tangent
+	
     {trigger: /([^\\])(arcsin|sin|arccos|cos|arctan|tan|csc|sec|cot)/, replacement: "[[0]]\\[[1]]", options: "rmA", description: "Add backslash before trig funcs"},
 
     {trigger: /\\(arcsin|sin|arccos|cos|arctan|tan|csc|sec|cot)([A-Za-gi-z])/,


### PR DESCRIPTION
Added snippet to turn "deg" into a degree symbol. Line is placed at the start of trigonometry for easier disabling if wanted. Set apart from sine, cos & tan snippets.