### PR TITLE
feat:  saving snippets in hidden folders

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,6 +211,7 @@ You can [view snippets written by others and share your own snippets here](https
 > [!WARNING]
 > Snippet files are interpreted as JavaScript and can execute arbitrary code.
 > Always be careful with snippets shared from others to avoid running malicious code.
+> Or when sharing the vault with others (files can be placed in places ignored by sync).
 
 
 ## Cheatsheet

--- a/esbuild.config.mjs
+++ b/esbuild.config.mjs
@@ -42,7 +42,10 @@ const args = {
 		"@codemirror/view",
 		"@lezer/highlight",
 		"@lezer/common",
-		"@lezer/lr"
+		"@lezer/lr",
+		"fs",
+		"path",
+		"os",
 		],
 	format: "cjs",
 	target: "es2016",

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,6 +1,6 @@
 import { Extension, Prec } from "@codemirror/state";
-import { Plugin, Notice, loadMathJax, addIcon } from "obsidian";
-import { onFileCreate, onFileChange, onFileDelete, getSnippetsFromFiles, getFileSets, getVariablesFromFiles, tryGetVariablesFromUnknownFiles } from "./settings/file_watch";
+import { Plugin, Notice, loadMathJax, addIcon, debounce } from "obsidian";
+import { getSnippetsFromFiles, getFileSets, getVariablesFromFiles, tryGetVariablesFromUnknownFiles, fileWatch } from "./settings/file_watch";
 import { LatexSuitePluginSettings, DEFAULT_SETTINGS, LatexSuiteCMSettings, processLatexSuiteSettings, LatexSuiteBasicSettings, LatexSuiteRawSettings } from "./settings/settings";
 import { isIMESupported, LatexSuiteSettingTab } from "./settings/settings_tab";
 import { ICONS } from "./settings/ui/icons";
@@ -22,6 +22,7 @@ export default class LatexSuitePlugin extends Plugin implements LatexSuitePlugin
 	settings: LatexSuitePluginSettings;
 	CMSettings: LatexSuiteCMSettings;
 	editorExtensions: Extension[] = [];
+	watcherCloser?: () => void;
 	disableMath = (view: EditorView) => {
 		try {
 			getContextPlugin(view, false).disableMath();
@@ -147,15 +148,15 @@ export default class LatexSuitePlugin extends Plugin implements LatexSuitePlugin
 	async getSnippets(becauseFileLocationUpdated: boolean, becauseFileUpdated: boolean) {
 		// Get files in snippet/variable folders.
 		// If either is set to be loaded from settings the set will just be empty.
-		const files = getFileSets(this);
+		const files = await getFileSets(this);
 
 		const snippetVariables =
 			this.settings.loadSnippetVariablesFromFile
-				? await getVariablesFromFiles(this, files)
+				? await getVariablesFromFiles(files)
 				: await this.getSettingsSnippetVariables();
 
 		// This must be done in either case, because it also updates the set of snippet files
-		const unknownFileVariables = await tryGetVariablesFromUnknownFiles(this, files);
+		const unknownFileVariables = await tryGetVariablesFromUnknownFiles(files);
 		if (this.settings.loadSnippetVariablesFromFile) {
 			// But we only use the values if the user wants them
 			Object.assign(snippetVariables, unknownFileVariables);
@@ -163,7 +164,7 @@ export default class LatexSuitePlugin extends Plugin implements LatexSuitePlugin
 
 		const snippets =
 			this.settings.loadSnippetsFromFile
-				? await getSnippetsFromFiles(this, files, snippetVariables)
+				? await getSnippetsFromFiles(files, snippetVariables)
 				: await this.getSettingsSnippets(snippetVariables);
 
 		this.showSnippetsLoadedNotice(snippets.length, Object.keys(snippetVariables).length,  becauseFileLocationUpdated, becauseFileUpdated);
@@ -172,6 +173,9 @@ export default class LatexSuitePlugin extends Plugin implements LatexSuitePlugin
 	}
 
 	async processSettings(becauseFileLocationUpdated = false, becauseFileUpdated = false) {
+		if (becauseFileLocationUpdated) {
+			this.watchFiles();
+		}
 		this.CMSettings = processLatexSuiteSettings(await this.getSnippets(becauseFileLocationUpdated, becauseFileUpdated), this.settings);
 		this.setEditorExtensions();
 		// Request Obsidian to reconfigure CM extensions
@@ -248,25 +252,22 @@ export default class LatexSuitePlugin extends Plugin implements LatexSuitePlugin
 		}
 		
 	}
+	
+	createWatcherCloser = debounce(async () => {
+		this.watcherCloser?.();
+		const newWatcherCloser = await fileWatch(this);
+		this.register(() => {
+			newWatcherCloser();
+		});
+		this.watcherCloser = newWatcherCloser ?? undefined;
+	}, 3000, true);
 
 	watchFiles() {
 		// Only begin watching files once the layout is ready
 		// Otherwise, we'll be unnecessarily reacting to many onFileCreate events of snippet files
 		// that occur when Obsidian first loads
 
-		this.app.workspace.onLayoutReady(() => {
-
-			const eventsAndCallbacks = {
-				"modify": onFileChange,
-				"delete": onFileDelete,
-				"create": onFileCreate
-			};
-
-			for (const [key, value] of Object.entries(eventsAndCallbacks)) {
-				// @ts-expect-error
-				this.registerEvent(this.app.vault.on(key, (file) => value(this, file)));
-			}
-		});
+		this.app.workspace.onLayoutReady(this.createWatcherCloser);
 	}
 
 	loadIcons() {

--- a/src/settings/file_watch.ts
+++ b/src/settings/file_watch.ts
@@ -1,9 +1,11 @@
 import LatexSuitePlugin from "../main";
-import { Vault, TFile, TFolder, TAbstractFile, Notice, debounce } from "obsidian";
+import { Vault, TFile, TFolder, TAbstractFile, Notice, debounce, Platform } from "obsidian";
 import { Snippet } from "../snippets/snippets";
 import { parseSnippets, parseSnippetVariables, type SnippetVariables } from "../snippets/parse";
 import { sortSnippets } from "src/snippets/sort";
 import { difference, intersection } from "src/utils/prototype_utils";
+
+type FSWatcher = ReturnType<typeof import("fs").watch>
 
 function isInFolder(file: TFile, dir: TFolder) {
 	let cur = file.parent;
@@ -36,6 +38,114 @@ const refreshFromFiles = debounce(async (plugin: LatexSuitePlugin) => {
 
 }, 500, true);
 
+/**
+ * Create a file watcher using either obsidian publics api, obsidians internal fs adapter for hidden files inside the vault
+ * or nodejs on the desktop for absolute paths.
+ * In case that people use sync with untrusted people, they can still use files while those files won't be synced.
+ */
+export async function fileWatch(plugin: LatexSuitePlugin) {
+	const snippetPath = plugin.settings.snippetsFileLocation;
+	const variablePath = plugin.settings.snippetVariablesFileLocation;
+	// Don't create 2 file watchers for the same file/folder.
+	if (plugin.settings.loadSnippetVariablesFromFile && plugin.settings.loadSnippetsFromFile) {
+		if (snippetPath === variablePath) {
+			return generateFileWatchers(plugin, snippetPath);
+		}
+		const startsWithSeperator = (path: string) => path.startsWith("/") || path.startsWith("\\");
+		if (snippetPath.startsWith(variablePath) && startsWithSeperator(variablePath.slice(snippetPath.length))) {
+			return generateFileWatchers(plugin, snippetPath);
+		} else if (variablePath.startsWith(snippetPath) && startsWithSeperator(snippetPath.slice(variablePath.length))) {
+			return generateFileWatchers(plugin, variablePath);
+		}
+		const snippetCloser = await generateFileWatchers(plugin, snippetPath);
+		const variableCloser = await generateFileWatchers(plugin, variablePath);
+		return () => {
+			snippetCloser();
+			variableCloser();
+		}
+	}
+		
+	const variablesWatcher = plugin.settings.loadSnippetVariablesFromFile
+		? await generateFileWatchers(
+				plugin,
+				plugin.settings.snippetVariablesFileLocation,
+			)
+		: null;
+	const snippetsWatcher = plugin.settings.loadSnippetsFromFile
+		? await generateFileWatchers(plugin, plugin.settings.snippetsFileLocation)
+		: null;	
+
+	return () => {
+		variablesWatcher?.();
+		snippetsWatcher?.();
+	}
+}
+
+async function AbsolutePath(path: string) {
+	if (!Platform.isDesktop) {
+		return null
+	}
+	const fs = require("fs") as typeof import("fs");
+	const node_path = require("path") as typeof import("path");
+	if (path.slice(0, 2) === "~/") {
+		const os = require("os") as typeof import("os");
+		const homeDir = os.homedir();
+		path = node_path.join(homeDir, path.slice(2));
+	}
+	if (!node_path.isAbsolute(path)) {
+		return null;
+	}
+	return {fs, node_path, path}
+}
+
+async function generateFileWatchers(plugin: LatexSuitePlugin, path: string) {
+	const vault = plugin.app.vault;
+	const fileOrFolder = vault.getAbstractFileByPath(path);
+	if (fileOrFolder) {
+		const events = [	
+			vault.on("modify", (file) => onFileChange(plugin, file)),
+			vault.on("create", (file) => onFileChange(plugin, file)),
+			vault.on("delete", (file) => onFileChange(plugin, file)),
+		]
+		return () => events.forEach(event => vault.offref(event));
+	}
+	const nodeLibs = await AbsolutePath(path)
+	if (nodeLibs !== null) {
+		const fs = nodeLibs.fs;
+		path = nodeLibs.path;
+		const watcher = fs.watch(path, { recursive: true }, (event, _filename) => {
+			if (event === "rename") return;
+			refreshFromFiles(plugin);
+		})
+		return () => watcher.close();
+	}
+	const stat = await vault.adapter.stat(path);
+	if (stat) {
+		type InternalFs = {
+			fs?: {
+				watch?: (
+					path: string,
+					options: { recursive: boolean },
+					callback: (event: "change"| "rename", filename: string) => void,
+				) => FSWatcher;
+			};
+			getFullPath?: (path: string) => string;
+		};
+		const adapter = vault.adapter as unknown as InternalFs;
+		const fullPath = adapter.getFullPath?.(path);
+		if (!fullPath) {
+			return () => {};
+		}
+
+		const watcher = adapter.fs?.watch?.(fullPath, { recursive: true }, (event, _filename) => {
+			if (event === "rename") return;
+			refreshFromFiles(plugin);
+		})
+		return () => watcher?.close();
+	}
+	return () => {};
+}
+
 export const onFileChange = async (plugin: LatexSuitePlugin, file: TAbstractFile) => {
 	if (!(file instanceof TFile)) return;
 
@@ -43,29 +153,6 @@ export const onFileChange = async (plugin: LatexSuitePlugin, file: TAbstractFile
 		|| plugin.settings.loadSnippetsFromFile && file.path === plugin.settings.snippetsFileLocation
 		|| fileIsInFolder(plugin, plugin.settings.snippetVariablesFileLocation, file)
 		|| fileIsInFolder(plugin, plugin.settings.snippetsFileLocation, file)
-	) {
-		refreshFromFiles(plugin);
-	}
-}
-
-export const onFileCreate = (plugin: LatexSuitePlugin, file: TAbstractFile) => {
-	if (!(file instanceof TFile)) return;
-
-	if (plugin.settings.loadSnippetVariablesFromFile && fileIsInFolder(plugin,plugin.settings.snippetVariablesFileLocation, file)
-		|| plugin.settings.loadSnippetsFromFile && fileIsInFolder(plugin,plugin.settings.snippetsFileLocation, file)
-	) {
-		refreshFromFiles(plugin);
-	}
-}
-
-export const onFileDelete = (plugin: LatexSuitePlugin, file: TAbstractFile) => {
-	if (!(file instanceof TFile)) return;
-
-	const snippetVariablesDir = plugin.app.vault.getAbstractFileByPath(plugin.settings.snippetVariablesFileLocation);
-	const snippetDir = plugin.app.vault.getAbstractFileByPath(plugin.settings.snippetsFileLocation);
-
-	if (plugin.settings.loadSnippetVariablesFromFile && snippetVariablesDir instanceof TFolder && file.path.contains(snippetVariablesDir.path)
-		|| plugin.settings.loadSnippetsFromFile && snippetDir instanceof TFolder && file.path.contains(snippetDir.path)
 	) {
 		refreshFromFiles(plugin);
 	}
@@ -80,45 +167,141 @@ function* generateFilesWithin(fileOrFolder: TAbstractFile): Generator<TFile> {
 			yield* generateFilesWithin(child);
 }
 
-function getFilesWithin(vault: Vault, path: string): Set<TFile> {
-	const fileOrFolder = vault.getAbstractFileByPath(path);
-	if (!fileOrFolder) {
-		console.warn(`Could not find file or folder at path ${path}`);
-		return new Set<TFile>();
+type FsLike = {
+	stat: (path: string) => Promise<{ type: "file" | "folder"} | null>;
+	list: (path: string) => Promise<{ files: string[] }>;
+	read: (path: string) => Promise<string>;
+}
+
+async function walkRecursive(path: string, fsLike: FsLike): Promise<File[]> {
+	const stat = await fsLike.stat(path);
+	if (stat?.type === "file") {
+		const name = path.split("/").pop() || path;
+		const read = () => fsLike.read(path);
+		return [{ name, path, read }];
+	} else if (stat?.type === "folder") {
+		const files = await fsLike.list(path);
+		const promises = files.files.map(
+			async (file) => await walkRecursive(file, fsLike),
+		);
+		return (await Promise.all(promises)).flat();
 	}
-	const files = generateFilesWithin(fileOrFolder);
-	return new Set(files);
+	return [];
+}
+
+// Async helper functions such as Array.fromAsync still are not widely supported/in proposal stages.
+async function generateFilesWithinHidden(vault: Vault, path: string): Promise<File[] | null> {
+	const hiddenFileOrFolder = await vault.adapter.exists(path);
+	if (hiddenFileOrFolder === null) {
+		return null;
+	}
+	const files = await walkRecursive(path, vault.adapter);
+	return files
+}
+
+async function genereteFilesWithinAbsolutePaths(path: string): Promise<File[] | null> {
+	if (!Platform.isDesktop) {
+		return null
+	}
+	const nodeLibs = await AbsolutePath(path);
+	if (nodeLibs === null) {
+		return null;
+	}
+	const fs = nodeLibs.fs.promises;
+	const node_path = nodeLibs.node_path;
+	path = nodeLibs.path;
+	const fileStat = await fs.stat(path).catch(() => null);
+	if (fileStat === null) {
+		return null;
+	}
+	async function stat(path: string) {
+		const fileStat = await fs.stat(path).catch(() => null);
+		if (fileStat === null) {
+			return null;
+		}
+		if (fileStat.isFile()) {
+			return { type: "file" as const };
+		} else if (fileStat.isDirectory()) {
+			return { type: "folder" as const };
+		}
+		return null;
+	}
+	const read = (path: string) => fs.readFile(path, "utf-8");
+	const list = async (path: string) => {
+		const files = await fs.readdir(path);
+		return { files: files.map((file) => node_path.join(path, file)) };
+	};
+	const files = await walkRecursive(path, { stat, list, read });
+	return files
+}
+
+async function getFilesWithin(vault: Vault, path: string): Promise<File[]> {
+	const fileOrFolder = vault.getAbstractFileByPath(path);
+	if (fileOrFolder) {
+		const files = generateFilesWithin(fileOrFolder);
+		return Array.from(files).map((file) => ({
+			path: file.path,
+			name: file.name,
+			read: () => vault.cachedRead(file),
+		}));
+	}
+	const absoluteFiles = await genereteFilesWithinAbsolutePaths(path);
+	if (absoluteFiles) {
+		return absoluteFiles;
+	}
+	const hiddenFiles = await generateFilesWithinHidden(vault, path);
+	if (hiddenFiles) {
+		return hiddenFiles;
+	}
+	return [];
+}
+
+/**
+ * Abstraction for a file which can either be a TFile from the vault, a hidden file or a file in a hidden folder 
+ * or on desktop only an absolute path to a file outside the vault.
+ */
+type File = {
+	path: string;
+	name: string;
+	read: () => Promise<string>;
 }
 
 interface FileSets {
-	definitelyVariableFiles: Set<TFile>;
-	definitelySnippetFiles: Set<TFile>;
-	snippetOrVariableFiles: Set<TFile>;
+	definitelyVariableFiles: Set<File>;
+	definitelySnippetFiles: Set<File>;
+	snippetOrVariableFiles: Set<File>;
 }
 
-export function getFileSets(plugin: LatexSuitePlugin): FileSets {
+export async function getFileSets(plugin: LatexSuitePlugin): Promise<FileSets> {
 	const variablesFolder =
 		plugin.settings.loadSnippetVariablesFromFile
-		? getFilesWithin(plugin.app.vault, plugin.settings.snippetVariablesFileLocation)
-		: new Set<TFile>();
+		? await getFilesWithin(plugin.app.vault, plugin.settings.snippetVariablesFileLocation)
+		: [];
 
 	const snippetsFolder =
 		plugin.settings.loadSnippetsFromFile
-		? getFilesWithin(plugin.app.vault, plugin.settings.snippetsFileLocation)
-			: new Set<TFile>();
+		? await getFilesWithin(plugin.app.vault, plugin.settings.snippetsFileLocation)
+		: [];
+	const variablePathSet = new Set(variablesFolder.map(file => file.path));
+	const snippetPathSet = new Set(snippetsFolder.map(file => file.path));	
 
-	const definitelyVariableFiles = difference(variablesFolder, snippetsFolder);
-	const definitelySnippetFiles = difference(snippetsFolder, variablesFolder);
-	const snippetOrVariableFiles = intersection(variablesFolder, snippetsFolder);
+	const definitelyVariablePaths = difference(variablePathSet, snippetPathSet);
+	const definitelyVariableFiles = new Set(variablesFolder.filter(file => definitelyVariablePaths.has(file.path)))
+
+	const definitelySnippetPaths = difference(snippetPathSet, variablePathSet);
+	const definitelySnippetFiles = new Set(snippetsFolder.filter(file => definitelySnippetPaths.has(file.path)))
+
+	const snippetOrVariablePaths = intersection(variablePathSet, snippetPathSet);
+	const snippetOrVariableFiles = new Set(variablesFolder.filter(file => snippetOrVariablePaths.has(file.path)))
 
 	return {definitelyVariableFiles, definitelySnippetFiles, snippetOrVariableFiles};
 }
 
-export async function getVariablesFromFiles(plugin: LatexSuitePlugin, files: FileSets) {
+export async function getVariablesFromFiles(files: FileSets) {
 	const snippetVariables: SnippetVariables = {};
 
 	for (const file of files.definitelyVariableFiles) {
-		const content = await plugin.app.vault.cachedRead(file);
+		const content = await file.read();
 		try {
 			Object.assign(snippetVariables, await parseSnippetVariables(content, file.path));
 		} catch (e) {
@@ -131,11 +314,11 @@ export async function getVariablesFromFiles(plugin: LatexSuitePlugin, files: Fil
 	return snippetVariables;
 }
 
-export async function tryGetVariablesFromUnknownFiles(plugin: LatexSuitePlugin, files: FileSets) {
+export async function tryGetVariablesFromUnknownFiles(files: FileSets) {
 	const snippetVariables: SnippetVariables = {};
 
 	for (const file of files.snippetOrVariableFiles) {
-		const content = await plugin.app.vault.cachedRead(file);
+		const content = await file.read();
 		try {
 			Object.assign(snippetVariables, await parseSnippetVariables(content, file.path));
 			files.definitelyVariableFiles.add(file);
@@ -151,14 +334,13 @@ export async function tryGetVariablesFromUnknownFiles(plugin: LatexSuitePlugin, 
 }
 
 export async function getSnippetsFromFiles(
-	plugin: LatexSuitePlugin,
 	files: FileSets,
 	snippetVariables: SnippetVariables
 ) {
 	const snippets: Snippet[] = [];
 
 	for (const file of files.definitelySnippetFiles) {
-		const content = await plugin.app.vault.cachedRead(file);
+		const content = await file.read();
 		try {
 			snippets.push(...await parseSnippets(content, snippetVariables, file.path));
 		} catch (e) {

--- a/src/settings/settings_tab.ts
+++ b/src/settings/settings_tab.ts
@@ -95,9 +95,7 @@ export class LatexSuiteSettingTab extends PluginSettingTab {
 
 		const snippetsFileLocDesc = new DocumentFragment();
 		snippetsFileLocDesc.createDiv({}, div => {
-			div.appendText("The file or folder to load snippets from. The file or folder must be within your vault, and not within a hidden folder (such as ")
-			div.createEl("code", { text: `.obsidian${""}/` });
-			div.appendText(").")
+			div.appendText("The file or folder to load snippets from. On desktop you can use ~/ or an absolute path. Files outside your vault or in hidden folders may not be watched for changes depending on your os.")
 		});
 
 		const snippetsFileLoc = new Setting(containerEl)
@@ -487,9 +485,7 @@ export class LatexSuiteSettingTab extends PluginSettingTab {
 
 		const snippetVariablesFileLocDesc = new DocumentFragment();
 		snippetVariablesFileLocDesc.createDiv({}, (div) => {
-			div.appendText("The file or folder to load snippet variables from. The file or folder must be within your vault, and not within a hidden folder (such as ")
-			div.createEl("code", { text: `.obsidian${""}/` });
-			div.appendText(").")
+			div.appendText("The file or folder to load snippets from. On desktop you can use ~/ or an absolute path. Files outside your vault or in hidden folders may not be watched for changes depending on your os.")
 		});
 
 		const snippetVariablesFileLoc = new Setting(containerEl)


### PR DESCRIPTION
Fixes #67

allow files to be saved in hidden folders or outside the vault on desktop.