### PR TITLE
Fix/snippets editor

### DIFF
--- a/src/settings/settings_tab.ts
+++ b/src/settings/settings_tab.ts
@@ -791,8 +791,7 @@ export class LatexSuiteSettingTab extends PluginSettingTab {
 
 		extensions.push(change);
 
-		this.snippetsEditor = createCMEditor(this.plugin.settings.snippets, extensions);
-		customCSSWrapper.appendChild(this.snippetsEditor.dom);
+		this.snippetsEditor = createCMEditor(this.plugin.settings.snippets, extensions, customCSSWrapper);
 
 
 		const buttonsDiv = snippetsFooter.createDiv("snippets-editor-buttons");
@@ -878,9 +877,10 @@ class ConfirmationModal extends Modal {
 	}
 }
 
-function createCMEditor(content: string, extensions: Extension[]) {
+function createCMEditor(content: string, extensions: Extension[], node: Element) {
 	const view = new EditorView({
 		state: EditorState.create({ doc: content, extensions }),
+		parent: node,
 	});
 
 	return view;


### PR DESCRIPTION
fixes #582

pass container when initializing instead of inserting afterwards as codemirror was upgraded in 1.13 and probably changed behaviour because of that.