### PR TITLE
fix: failed to load on first install

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -82,7 +82,8 @@ export default class LatexSuitePlugin extends Plugin implements LatexSuitePlugin
 
 	async loadSettings() {
 
-		let data = v.parse(v.record(v.string(), v.any()), await this.loadData());
+		// data can be empty.
+		let data = v.parse(v.record(v.string(), v.any()), await this.loadData() ?? {});
 
 		// Migrate settings from v1.8.0 - v1.8.4
 		const shouldMigrateSettings = data ? "basicSettings" in data : false;


### PR DESCRIPTION
Fixes #590

when `data.json` doesn't exist, `this.loadData` returns null, causing  the plugin to not load