### PR TITLE
feat: math tooltip in live preview

### DIFF
--- a/src/editor_extensions/math_tooltip.ts
+++ b/src/editor_extensions/math_tooltip.ts
@@ -214,9 +214,9 @@ export function handleMathTooltip(update: ViewUpdate) {
 
 function shouldShowTooltip(state: EditorState, ctx: Context): Bounds | null {
 	if (!ctx.mode.inMath()) return null;
-
+	const settings = getLatexSuiteConfig(state);
 	const isLivePreview = state.field(editorLivePreviewField);
-	if (ctx.mode.blockMath && isLivePreview) return null;
+	if (ctx.mode.blockMath && isLivePreview && !settings.mathPreviewLivePreviewDisplay) return null;
 
 	const eqnBounds = ctx.getBounds();
 	if (!eqnBounds) return null;

--- a/src/settings/settings.ts
+++ b/src/settings/settings.ts
@@ -28,6 +28,7 @@ export interface LatexSuiteBasicSettings {
 	mathPreviewPositionIsAbove: boolean;
 	mathPreviewCursor: string;
 	mathPreviewBracketHighlighting: boolean;
+	mathPreviewLivePreviewDisplay: boolean;
 	autofractionSymbol: string;
 	autofractionBreakingChars: string;
 	matrixShortcutsEnabled: boolean;
@@ -103,6 +104,7 @@ export const DEFAULT_SETTINGS: LatexSuitePluginSettings = {
 	mathPreviewPositionIsAbove: true,
 	mathPreviewCursor: "▶",
 	mathPreviewBracketHighlighting: false,
+	mathPreviewLivePreviewDisplay: false,
 	autofractionEnabled: true,
 	autofractionSymbol: "\\frac",
 	autofractionBreakingChars: "+-=\t",

--- a/src/settings/settings_tab.ts
+++ b/src/settings/settings_tab.ts
@@ -273,7 +273,23 @@ export class LatexSuiteSettingTab extends PluginSettingTab {
 					this.plugin.settings.mathPreviewBracketHighlighting = value;
 					await this.plugin.saveSettings();
 				}));
-		const mathPreviewDependentSettings = [positionSetting, cursorSetting, highlightSetting];
+		
+		const livePreviewDisplay = new Setting(containerEl)
+			.setName("Display live preview")
+			.setDesc(
+				"Whether to display the tooltip in live preview mode. " +
+					"The cursor and bracket highlighting will only be shown in this preview and not in obsidian's preview. ",
+			)
+			.addToggle((toggle) =>
+				toggle
+				.setValue(this.plugin.settings.mathPreviewLivePreviewDisplay)
+				.onChange(async (value) => {
+					this.plugin.settings.mathPreviewLivePreviewDisplay =
+						value;
+					await this.plugin.saveSettings();
+				}));
+			
+		const mathPreviewDependentSettings = [positionSetting, cursorSetting, highlightSetting, livePreviewDisplay];
 		mathPreviewDependentSettings.forEach((setting) =>
 			setting.settingEl.toggleClass(
 				"hidden",


### PR DESCRIPTION
Fixes #592

Add toggle to show tooltip in live preview as the cursor and bracket highlighting won't be shown in obsidian's rendering.