### PR TITLE
fix: excalidraw support

### DIFF
--- a/src/editor_extensions/conceal_fns.ts
+++ b/src/editor_extensions/conceal_fns.ts
@@ -511,7 +511,7 @@ const macroMap = {
 	"text": handleText,
 	"set": handleSet,
 	"operatorname": handleOperatorName,
-} as Record<string, (cursor: TreeCursor, doc: EquationText, macro?: string) => HandleConcealResult>;
+} as Record<string, (cursor: TreeCursor, doc: EquationText, macro: string) => HandleConcealResult>;
 for (const macro of Object.keys(modifiers)) {
 	macroMap[macro] = handleModifier;
 }
@@ -585,7 +585,7 @@ export function conceal(
 				bound: eqn.bound,
 				overlay: {
 					from: eqn.overlay.from + lines_lengths[i],
-					to: eqn.overlay.to + lines_lengths[i],
+					to: eqn.overlay.from + lines_lengths[i + 1],
 				},
 			}))
 			.filter((line) => line.text.trim() !== "");

--- a/src/editor_extensions/highlight_dollar.ts
+++ b/src/editor_extensions/highlight_dollar.ts
@@ -86,6 +86,14 @@ class HighlightDollarPlugin implements PluginValue {
 
 		const widgets: Range<Decoration>[] = [];
 		for (const bounds of dollar_ranges) {
+			if (
+				(bounds.kind === "error" && bounds.from === bounds.to) ||
+				(bounds.kind === "pair" &&
+					bounds.outer_start === bounds.inner_start &&
+					bounds.inner_end === bounds.outer_end)
+			) {
+				continue;
+			}
 			if (bounds.kind === "error") {
 				widgets.push(
 					Decoration.mark({

--- a/src/parser/language.ts
+++ b/src/parser/language.ts
@@ -4,12 +4,13 @@
  * MIT License
  * Copyright (C) 2018-2021 by Marijn Haverbeke <marijnh@gmail.com> and others
  */
-import { ParseContext } from "@codemirror/language";
+import { language, ParseContext } from "@codemirror/language";
 import { ChangeSet, EditorState, StateEffect, StateField, Transaction } from "@codemirror/state";
 import { EditorView, logException, ViewPlugin, ViewUpdate } from "@codemirror/view";
 import { Parser, Tree } from "@lezer/common";
 import { fullMathParser } from "./mathjax-parser";
 import { getLatexSuiteConfig } from "src/snippets/codemirror/config";
+import { parser } from "./mathjax/latex-parser";
 
 export class Work {
 	// Milliseconds of work time to perform immediately for a state doc change
@@ -243,10 +244,15 @@ const parseWorker = ViewPlugin.fromClass(
 	},
 );
 
-const create = (state: EditorState) =>
-	LanguageState.init(
-		fullMathParser(getLatexSuiteConfig(state).forceMathLanguages),
-	)(state);
+const create = (state: EditorState) => {
+	// doesn't exist in the obsidians types definition.
+	const languageFacet = state.facet(language) as null | {name?: string}
+	const fullParser =
+		languageFacet?.name === "hypermd"
+			? fullMathParser(getLatexSuiteConfig(state).forceMathLanguages)
+			: parser;
+	return LanguageState.init(fullParser)(state);
+}
 const update = function languageUpdate(value: LanguageState, tr: Transaction) { 
 	for (let e of tr.effects) if (e.is(LanguageSetStateEffect)) return e.value
 	return value.apply(tr);

--- a/src/utils/context.ts
+++ b/src/utils/context.ts
@@ -18,6 +18,7 @@ import { SyntaxNode, SyntaxNodeRef } from "@lezer/common";
 import { allTextAreas, MacroArea, snippetLessArea } from "./default_text_areas";
 import { modifiedSyntaxTree } from "src/parser/language";
 import { Type } from "src/parser/mathjax-parser";
+import * as latex from "src/parser/mathjax/latex-parser.terms";
 
 const OPEN_INLINE_MATH_NODE =
 	"formatting_formatting-math_formatting-math-begin_keyword_math";
@@ -662,7 +663,7 @@ class MathBoundsPlugin implements PluginValue {
 						const lastNode = contentNodes.last();
 						if (!lastNode) return;
 						const tree = nodeRef.node.enter(lastNode.to, -1);
-						if (tree === null || tree.name !== "LaTeX") return;
+						if (tree === null || !tree.type.is(latex.LaTeX)) return;
 						ranges.push({
 							inner_start: contentNodes[0].from,
 							inner_end: lastNode.to,
@@ -672,10 +673,23 @@ class MathBoundsPlugin implements PluginValue {
 							tree,
 							overlay: contentNodes,
 						});
+					// for excalidraw the topnode is LaTeX but it's also a topnode in the mounted tree
+					// thus check if it has a parent instead.
+					} else if (nodeRef.type.is(latex.LaTeX) && nodeRef.node.parent === null) {
+						ranges.push({
+							inner_start: nodeRef.node.from,
+							inner_end: nodeRef.node.to,
+							outer_start: nodeRef.node.from,
+							outer_end: nodeRef.node.to,
+							mode: MathMode.BlockMath,
+							tree: nodeRef.node,
+							overlay: [{ from: nodeRef.from, to: nodeRef.to }],
+						});
 					}
 				},
 			});
 		}
+		console.log(ranges)
 		this._mathBounds = ranges;
 	}
 
@@ -695,7 +709,8 @@ class MathBoundsPlugin implements PluginValue {
 			const bound = bounds[mid];
 			if (pos < bound.outer_start) {
 				right = mid - 1;
-			} else if (pos >= bound.outer_end) {
+			// excalidraw doesn't have delimiters thus they have 0 length and should be ignored for this check
+			} else if (pos >= bound.outer_end && bound.outer_end !== bound.inner_end) {
 				left = mid + 1;
 			} else if (
 				pos < bound.inner_start &&

--- a/src/utils/tokenizer.ts
+++ b/src/utils/tokenizer.ts
@@ -130,7 +130,7 @@ export function* iterateTreeCursor(topNode: SyntaxNode, doc: EquationText) {
 		doc.skipCursorMove = false;
 		if (cursor.to > doc.to) continue
 		yield cursor;	
-	} while ((doc.skipCursorMove || cursor.next()) && cursor.from <= doc.to);
+	} while ((doc.skipCursorMove || cursor.next()) && cursor.from <= doc.to && cursor.node !== topNode);
 }
 export class EquationText {
 	public skipCursorMove: boolean = false;


### PR DESCRIPTION
The parser assumed markdown syntax, but excalidraw is only mathjax syntax. Thus check if the language's name is hypermd or not and add support for 0 width delimiters.