### PR TITLE
fix: file suggest on 1.13

### DIFF
--- a/src/parser/language.ts
+++ b/src/parser/language.ts
@@ -11,7 +11,6 @@ import { Parser, Tree } from "@lezer/common";
 import { fullMathParser } from "./mathjax-parser";
 import { getLatexSuiteConfig } from "src/snippets/codemirror/config";
 import { parser } from "./mathjax/latex-parser";
-import { Notice } from "obsidian";
 
 export class Work {
 	// Milliseconds of work time to perform immediately for a state doc change

--- a/src/settings/file_watch.ts
+++ b/src/settings/file_watch.ts
@@ -36,7 +36,7 @@ const refreshFromFiles = debounce(async (plugin: LatexSuitePlugin) => {
 
 	await plugin.processSettings(false, true);
 
-}, 500, true);
+}, 7000, true);
 
 /**
  * Create a file watcher using either obsidian publics api, obsidians internal fs adapter for hidden files inside the vault

--- a/src/settings/ui/file_suggest.ts
+++ b/src/settings/ui/file_suggest.ts
@@ -1,16 +1,16 @@
 // Credits to https://github.com/liamcain/obsidian-periodic-notes
 
-import { TAbstractFile, Vault } from "obsidian";
+import { AbstractInputSuggest, App, requireApiVersion, TAbstractFile, Vault } from "obsidian";
 
 import { TextInputSuggest } from "./suggest";
 
-export class FileSuggest extends TextInputSuggest<TAbstractFile> {
-	getSuggestions(inputStr: string): TAbstractFile[] {
+function createFileSuggest() {
+	function getSuggestions(app: App, inputStr: string): TAbstractFile[] {
 
 		const files: TAbstractFile[] = [];
 		const lowerCaseInputStr = inputStr.toLowerCase();
 
-		Vault.recurseChildren(this.app.vault.getRoot(), (file) => {
+		Vault.recurseChildren(app.vault.getRoot(), (file) => {
 			if (file.path.toLowerCase().contains(lowerCaseInputStr)) {
 				files.push(file);
 			}
@@ -19,13 +19,37 @@ export class FileSuggest extends TextInputSuggest<TAbstractFile> {
 		return files;
 	}
 
-	renderSuggestion(file: TAbstractFile, el: HTMLElement): void {
+	function renderSuggestion(file: TAbstractFile, el: HTMLElement): void {
 		el.setText(file.path);
 	}
+	if (requireApiVersion("1.4.10")) {
+		return class FileSuggest extends AbstractInputSuggest<TAbstractFile> {
+			getSuggestions(query: string) {
+				return getSuggestions(this.app, query)			
+			}	
 
-	selectSuggestion(file: TAbstractFile): void {
-		this.inputEl.value = file.path;
-		this.inputEl.trigger("input");
-		this.close();
+			renderSuggestion(file: TAbstractFile, el: HTMLElement): void {
+				return renderSuggestion(file, el)
+			}
+		}
+	} else {
+		return class FileSuggest extends TextInputSuggest<TAbstractFile> {
+			getSuggestions(inputStr: string): TAbstractFile[] {
+				return getSuggestions(this.app, inputStr)
+			}
+
+			renderSuggestion(file: TAbstractFile, el: HTMLElement): void {
+				return renderSuggestion(file, el)
+			}
+
+			selectSuggestion(file: TAbstractFile): void {
+				this.inputEl.value = file.path;
+				this.inputEl.trigger("input");
+				this.close();
+			}
+		}
 	}
+
 }
+
+export const FileSuggest = createFileSuggest()


### PR DESCRIPTION
Fixes #602

the suggestions weren't showing if the settings open up in a new window, thus using the built in implementation if it exists. And increase debounce as it doesn't need to give such instant feedback.