### PR TITLE
fix: move color and colorbox macros to textArea (fixes #612)

### DIFF
--- a/src/utils/default_text_areas.ts
+++ b/src/utils/default_text_areas.ts
@@ -27,6 +27,10 @@ export const textArea = [
 	{ name: "mbox" },
 	{ name: "fbox" },
 	{ name: "framebox" },
+	{ name: "textcolor", arguments: [0] }, // only the first argument is text/color, the second argument is math
+	{ name: "color" },
+	{ name: "colorbox" },
+	{ name: "fcolorbox" }, // has two inputs \fcolorbox{color}{background}{text} needs seperate handling
 ] as const satisfies readonly MacroArea[];
 
 /**
@@ -39,10 +43,6 @@ export const snippetLessArea = [
 	{ name: "end" },
 	{ name: "mmlToken" }, // MathML token, also has two inputs
 	{ name: "unicode" },
-	{ name: "textcolor", arguments: [0] }, // only the first argument is text/color, the second argument is math
-	{ name: "color" },
-	{ name: "colorbox" },
-	{ name: "fcolorbox" }, // has two inputs \fcolorbox{color}{background}{text} needs seperate handling
 ] as const satisfies readonly MacroArea[];
 
 export const allTextAreas = [...textArea, ...snippetLessArea] as const;


### PR DESCRIPTION
### Description
Resolves #612

This PR moves `color`, `textcolor`, `colorbox` and `fcolorbox` from `snippetLessArea` back to `textArea`. 

- **Preserves safety:** Evaluates the environment as `"text"`, natively blocking math-only (`m`) snippets to prevent rendering bugs.
- **Restores functionality:** Allows text-mode (`tA`) snippets to expand properly for text-literal arguments (e.g., `li` -> `lime`).

### Testing
- `\color{li}` successfully expands to `\color{lime}`.
- Math snippets remain blocked inside color/colorbox arguments.