### PR TITLE
snippet: add `nexists` to `exists`

### DIFF
--- a/src/default_snippets.js
+++ b/src/default_snippets.js
@@ -195,7 +195,7 @@ export default [
     {trigger: "sup=", replacement: "\\supseteq", options: "mA"},
 	{trigger: "eset", replacement: "\\emptyset", options: "mA"},
 	{trigger: "set", replacement: "\\{ $0 \\}$1", options: "mA"},
-	{trigger: "e\\xi sts", replacement: "\\exists", options: "mA", priority: 1},
+	{trigger: /(n?)e\\xi sts/, replacement: "\\[[0]]exists", options: "mA", priority: 1},
 
 	{trigger: "LL", replacement: "\\mathcal{L}", options: "mA"},
 	{trigger: "HH", replacement: "\\mathcal{H}", options: "mA"},


### PR DESCRIPTION
Fixes #611

the workaround snippet for `e \xi sts` only worked for `exists` and didn't check for a n before the `e`.