### PR TITLE
feat: unused capture groups

### DIFF
--- a/src/snippets/luasnip_api/node.ts
+++ b/src/snippets/luasnip_api/node.ts
@@ -140,12 +140,12 @@ export class SnippetStringNode extends BaseNode {
 		const replacements = []
 		for (const match of matches) {
 			const index = parseInt(match[1]);
-			if (captures.match[index] === undefined) {
+			if (index >= captures.match.length) {
 				continue;
 			}
 			const start = match.index;
 			const end = start + match[0].length;
-			const replacement = captures.match[index];
+			const replacement = captures.match[index] ?? "";
 			replacements.push({start, end, replacement})
 		}
 		return applyReplacements(this.snippet, replacements);


### PR DESCRIPTION
Replace unused capture groups with the empty string instead of the raw `[[X]]`. It's to allow snippets such as `(a)|(b)` which would have to be very verbose otherwise with an replacement function that does it instead. And this use case would be more common than the current behaviour.