### PR TITLE
feat: config textareas

### DIFF
--- a/DOCS.md
+++ b/DOCS.md
@@ -13,7 +13,8 @@
   triggerKey?: string = "",
   language?: string,
   excludedMacros?: string[],
-  excludedEnvironments: string[],
+  excludedEnvironments?: string[],
+  includedMacros?: string[],
 }
 ```
 
@@ -34,6 +35,7 @@
 - `language` (optional): Which code language to expand this in. Needs to match the text after <code>```</code> exactly.
 - `excludedMacros` (optional): Which macros\commands name to skip expansion in. Could be usefull for commands such as `ce` and `pu`.
 - `excludedEnvironments` (optional): Which environment names such as `pmatrix` to skip expansion in.
+- `includedMacros` (optional): Which macros\commands name to only do expansion in. Could be useful for commands such as `color` and `unicode`.
 
 ### Options
 - `t` : Text mode. Only run this snippet outside math
@@ -49,6 +51,7 @@
 	- The `math` language from https://github.com/ocapraro/obsidian-math-plus doesn't trigger code mode, but block math mode instead
 - `U`: Skip undo. When an automatic snippet expands, undo returns the editor to the state before the triggering key was typed, instead of restoring that key.
 - `C` : Inline code mode. Only run this snippet inside a `` ` ... ` `` block
+- `T` : Math text mode. Only run this inside text macros such as `\text{}`
 
 Multiple options can be used at once. As an exception, regex and visual are mutually exclusive.
 

--- a/README.md
+++ b/README.md
@@ -174,6 +174,7 @@ Snippets can be edited in the plugin settings. The structure of a snippet is as 
   language?: string,
   excludedMacros?: string[],
   excludedEnvironments?: string[],
+  includedMacros?: string[],
 }
 ```
 
@@ -189,6 +190,7 @@ Snippets can be edited in the plugin settings. The structure of a snippet is as 
 - `language` (optional): Code language for snippets.
 - `excludedMacros` (optional): Macros to exclude this snippet.
 - `excludedEnvironments` (optional): Environments to exclude this snippet.
+- `includedMacros` (optional): Macros to include this snippet.
 
 
 #### Options
@@ -203,6 +205,7 @@ Snippets can be edited in the plugin settings. The structure of a snippet is as 
 - `c` : Code mode. Only run this snippet inside a ```` ``` ... ``` ```` block
 - `U`: Skip undo. When an automatic snippet expands, pressing undo returns to the state before the trigger key was typed, instead of first removing the snippet and reinserting that key.
 - `C` : Inline code mode. Only run this snippet inside a `` ` ... ` `` block
+- `T` : Math text mode. Only run this inside text macros such as `\text{}`
 
 Insert **tabstops** for the cursor to jump to by writing "$0", "$1", etc. in the `replacement`.
 

--- a/src/default_snippets.js
+++ b/src/default_snippets.js
@@ -1,6 +1,7 @@
 export default [
     // Math mode
 	{trigger: "mk", replacement: "$$0$", options: "tA"},
+	{trigger: "mk", replacement: "\\($0\\)", options: "TA"},
     {trigger: "dm", replacement: "$$\n$0\n$$", options: "tAw"},
 	{trigger: /(\S\s*)dm/, replacement: "[[0]]\n$$\n$0\n$$", options: "tAw", priority: 1},
 

--- a/src/features/run_snippets.ts
+++ b/src/features/run_snippets.ts
@@ -6,7 +6,7 @@ import { expandSnippets } from "src/snippets/snippet_management";
 import { Context, getContextPlugin } from "src/utils/context";
 import { autoEnlargeBrackets } from "./auto_enlarge_brackets";
 import { snippetDebugLevel } from "src/settings/settings";
-import { Snippet, SnippetType } from "src/snippets/snippets";
+import { IncludedEnvironmentResult, Snippet, SnippetType } from "src/snippets/snippets";
 import { showSnippetInfo } from "src/editor_extensions/obsidian_utils";
 
 type SnippetInfo = {
@@ -68,10 +68,14 @@ const runSnippetCursor = (view: EditorView, ctx: Context, snippetInfo: SnippetIn
 	const updatedLine = line + key;
 	for (let i=0; i < snippetInfo.snippets.length; i++) {
 		const snippet = snippetInfo.snippets[i];
-
-		if (!snippet.options.snippetShouldRunInMode(ctx.mode)) {
+		const inIncludedScope = snippet.isWithinIncludedScope(envNames);
+		if (!snippet.options.snippetShouldRunInMode(ctx.mode, inIncludedScope === IncludedEnvironmentResult.Included)) {
 			continue;
 		}
+		
+		if (inIncludedScope === IncludedEnvironmentResult.NotIncluded) {
+			continue;
+		}	
 
 		const result = snippet.process(updatedLine, range, sel, effectiveLineAfter);
 		if (result === null) continue;

--- a/src/snippets/options.ts
+++ b/src/snippets/options.ts
@@ -42,8 +42,8 @@ export class Options {
 		return options;
 	}
 
-	snippetShouldRunInMode(mode: Mode) {
-		if (mode.snippetlessEnv) {
+	snippetShouldRunInMode(mode: Mode, ignoreSnippetLessEnv: boolean = false): boolean {
+		if (mode.snippetlessEnv && !ignoreSnippetLessEnv) {
 			return false
 		}
 		if (
@@ -74,6 +74,7 @@ export class Options {
 		if (this.mode.code && mode.code) {
 			return true;
 		}
+		return false;
 	}
 }
 
@@ -146,6 +147,9 @@ export class Mode {
 				case "t":
 					mode.text = true;
 					break;
+				case "T":
+					mode.textEnv = true;
+					break;
 				case "c":
 					mode.codeBlock = true;
 					break;
@@ -157,6 +161,11 @@ export class Mode {
 
 		if (language !== undefined) {
 			mode.codeBlock = language;
+		}
+		
+		if (mode.textEnv && !(mode.blockMath || mode.inlineMath)) {
+			mode.blockMath = true;
+			mode.inlineMath = true;
 		}
 
 		if (!(mode.text ||

--- a/src/snippets/parse.ts
+++ b/src/snippets/parse.ts
@@ -1,4 +1,4 @@
-import { optional, object, string as string_, union, parse, number, InferOutput as Output, custom, instance, array, pipe, transform, mapItems } from "valibot";
+import { optional, object, string as string_, union, parse, number, InferOutput as Output, custom, instance, array, pipe, transform } from "valibot";
 import { RegexSnippet, serializeSnippetLike, Snippet, StringSnippet, VISUAL_SNIPPET_MAGIC_SELECTION_PLACEHOLDER, VisualSnippet } from "./snippets";
 import { Options } from "./options";
 import { sortSnippets } from "./sort";
@@ -6,7 +6,7 @@ import { EXCLUSIONS } from "./environment";
 import { Platform } from "obsidian";
 import { api } from "./luasnip_api";
 import { ArrayNode, BaseNode, SnippetStringNode, SnippetTabstopOnlyNode, VisualSnippetNode } from "./luasnip_api/node";
-import { MacroArea, MacroAreaSchema } from "src/utils/default_text_areas";
+import { MacroArea, MacroAreaPipeSchema } from "src/utils/default_text_areas";
 
 export type SnippetVariables = Record<string, string>;
 
@@ -144,11 +144,9 @@ const RawSnippetSchema = object({
 	description: optional(string_(), "no description provided"),
 	triggerKey: optional(string_(), ""),
 	language: optional(string_()),
-	excludedMacros: pipe(
-		optional(array(union([string_(), MacroAreaSchema])), []),
-		mapItems((item) => (typeof item === "string" ? { name: item } : item)),
-	),
+	excludedMacros: MacroAreaPipeSchema,
 	excludedEnvironments: optional(array(string_()), []),
+	includedMacros: MacroAreaPipeSchema,
 });
 
 type RawSnippet = Output<typeof RawSnippetSchema>;
@@ -176,7 +174,14 @@ function validateRawSnippets(snippets: unknown): RawSnippet[] {
  * - if it is a regex snippet, the trigger is represented as a RegExp instance with flags set
  */
 function parseSnippet(raw: RawSnippet, snippetVariables: SnippetVariables): Snippet {
-	const { replacement: replacementRaw, priority, description, excludedEnvironments: excludedEnvironments, excludedMacros: userExcludedMacros } = raw;
+	const {
+		replacement: replacementRaw,
+		priority,
+		description,
+		excludedEnvironments: excludedEnvironments,
+		excludedMacros: userExcludedMacros,
+		includedMacros
+	} = raw;
 	const options = Options.fromSource(raw.options, raw.language);
 	const triggerKey = parseKeyName(raw.triggerKey);
 
@@ -244,7 +249,7 @@ function parseSnippet(raw: RawSnippet, snippetVariables: SnippetVariables): Snip
 
 		options.regex = true;
 
-		const normalised = { trigger, replacement, options, priority, description, excludedMacros, triggerKey, triggerAfter, excludedEnvironments };
+		const normalised = { trigger, replacement, options, priority, description, excludedMacros, triggerKey, triggerAfter, excludedEnvironments, includedMacros };
 
 		return new RegexSnippet(normalised);
 	}
@@ -273,7 +278,7 @@ function parseSnippet(raw: RawSnippet, snippetVariables: SnippetVariables): Snip
 				typeof raw.replacement === "string"
 					? new ArrayNode([new VisualSnippetNode(raw.replacement)])
 					: raw.replacement;
-			const normalised = { trigger, replacement, options, priority, description, excludedEnvironments, excludedMacros, triggerKey, triggerAfter };
+			const normalised = { trigger, replacement, options, priority, description, excludedEnvironments, excludedMacros, includedMacros, triggerKey, triggerAfter };
 			return new VisualSnippet(normalised);
 		}
 		else {
@@ -281,7 +286,7 @@ function parseSnippet(raw: RawSnippet, snippetVariables: SnippetVariables): Snip
 				typeof raw.replacement === "string"
 					? new ArrayNode([new SnippetTabstopOnlyNode(raw.replacement)])
 					: raw.replacement;
-			const normalised = { trigger, replacement, options, priority, description, excludedEnvironments, excludedMacros, triggerKey, triggerAfter };
+			const normalised = { trigger, replacement, options, priority, description, excludedEnvironments, excludedMacros, includedMacros, triggerKey, triggerAfter };
 			return new StringSnippet(normalised);
 		}
 	}

--- a/src/snippets/snippets.ts
+++ b/src/snippets/snippets.ts
@@ -75,6 +75,12 @@ export type ProcessSnippetResult =
 	| { triggerPos: number, replacement: ResultInsert, triggerEndPos?: number }
 	| null
 
+export enum IncludedEnvironmentResult {
+	None,
+	Included,
+	NotIncluded
+}
+
 /**
  * a snippet instance contains all the information necessary to run a snippet.
  * snippet data specific to a certain type of snippet is in its `data` property.
@@ -89,6 +95,7 @@ export abstract class Snippet<T extends SnippetType = SnippetType> {
 
 	excludedEnvironments: string[];
 	excludedMacros: MacroArea[] = [];
+	includedMacros: MacroArea[] = [];
 
 	constructor(
 		type: T,
@@ -99,6 +106,7 @@ export abstract class Snippet<T extends SnippetType = SnippetType> {
 		description: string = "no description provided",
 		excludedEnvironments: string[] = [],
 		excludedMacros: MacroArea[] = [],
+		includedMacros: MacroArea[] = [],
 		triggerKey: string = "",
 	) {
 		this.type = type;
@@ -109,6 +117,7 @@ export abstract class Snippet<T extends SnippetType = SnippetType> {
 		this.description = description;
 		this.excludedEnvironments = excludedEnvironments;
 		this.excludedMacros = excludedMacros;
+		this.includedMacros = includedMacros;
 		this.triggerKey = triggerKey;
 	}
 
@@ -136,6 +145,17 @@ export abstract class Snippet<T extends SnippetType = SnippetType> {
 		}
 		return false;
 	}
+	
+	isWithinIncludedScope(stack: StackOutput[]): IncludedEnvironmentResult {
+		if (this.includedMacros.length === 0) return IncludedEnvironmentResult.None;
+		if (stack.length === 0) return IncludedEnvironmentResult.NotIncluded
+		const firstName = stack[0]
+		if (firstName.kind === "math" || firstName.kind === "environment")
+			return IncludedEnvironmentResult.NotIncluded;
+		if (isMacroArgumentCount(firstName, this.includedMacros))
+			return IncludedEnvironmentResult.Included;
+		return IncludedEnvironmentResult.NotIncluded;
+	}
 
 	toString() {
 		return serializeSnippetLike({
@@ -152,8 +172,8 @@ export abstract class Snippet<T extends SnippetType = SnippetType> {
 }
 
 export class VisualSnippet extends Snippet<"visual"> {
-	constructor({ trigger, replacement, options, priority, description, excludedEnvironments, excludedMacros, triggerKey }: CreateSnippet<"visual">) {
-		super("visual", trigger, replacement, options, priority, description, excludedEnvironments, excludedMacros, triggerKey);
+	constructor({ trigger, replacement, options, priority, description, excludedEnvironments, excludedMacros, includedMacros, triggerKey }: CreateSnippet<"visual">) {
+		super("visual", trigger, replacement, options, priority, description, excludedEnvironments, excludedMacros, includedMacros, triggerKey);
 	}
 
 	process(effectiveLine: string, range: SelectionRange, sel: string): ProcessSnippetResult {
@@ -185,8 +205,8 @@ export class VisualSnippet extends Snippet<"visual"> {
 
 export class RegexSnippet extends Snippet<"regex"> {
 
-	constructor({ trigger, replacement, options, priority, description, excludedEnvironments, excludedMacros, triggerKey, triggerAfter}: CreateSnippet<"regex">) {
-		super("regex", trigger, replacement, options, priority, description, excludedEnvironments, excludedMacros, triggerKey);
+	constructor({ trigger, replacement, options, priority, description, excludedEnvironments, excludedMacros, includedMacros, triggerKey, triggerAfter}: CreateSnippet<"regex">) {
+		super("regex", trigger, replacement, options, priority, description, excludedEnvironments, excludedMacros, includedMacros, triggerKey);
 		this.data.triggerAfter = triggerAfter;
 	}
 
@@ -226,8 +246,8 @@ export class RegexSnippet extends Snippet<"regex"> {
 export class StringSnippet extends Snippet<"string"> {
 	data: SnippetData<"string">;
 
-	constructor({ trigger, replacement, options, priority, description, excludedEnvironments: excludeIn, excludedMacros, triggerKey, triggerAfter }: CreateSnippet<"string">) {
-		super("string", trigger, replacement, options, priority, description, excludeIn, excludedMacros, triggerKey);
+	constructor({ trigger, replacement, options, priority, description, excludedEnvironments: excludeIn, excludedMacros, includedMacros, triggerKey, triggerAfter }: CreateSnippet<"string">) {
+		super("string", trigger, replacement, options, priority, description, excludeIn, excludedMacros, includedMacros, triggerKey);
 		this.data.triggerAfter = triggerAfter;
 	}
 
@@ -279,6 +299,7 @@ type CreateSnippet<T extends SnippetType> = {
 	description?: string;
 	excludedEnvironments?: string[];
 	excludedMacros?: MacroArea[];
+	includedMacros?: MacroArea[];
 	triggerKey?: string;
 } & SnippetData<T>
 

--- a/src/utils/default_text_areas.ts
+++ b/src/utils/default_text_areas.ts
@@ -1,9 +1,14 @@
 import * as v from "valibot"
-export const MacroAreaSchema = v.object({
+const MacroAreaSchema = v.object({
 	name: v.string(),
 	arguments: v.optional(v.array(v.number())),
 });
 export type MacroArea = v.InferOutput<typeof MacroAreaSchema>;
+
+export const MacroAreaPipeSchema = v.pipe(
+		v.optional(v.array(v.union([v.string(), MacroAreaSchema])), []),
+		v.mapItems((item) => (typeof item === "string" ? { name: item } : item)),
+)
 /**
  * List of environments where math commands are illegal to insert.
  * this is a mix of text and color environments where for example \color{#1} computes #1 as colorcode


### PR DESCRIPTION
Fixes #612

Allow the user to ignore the snippetlesseEnv list such as for macros as color. Change `\text{}` to its own option as snippets in markdown shouldn't expand in `\text` and vice-versa.