### PR TITLE
migrate to 1.13 settings api

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,4 @@ data.json
 **/parser/*/*-parser.js
 **/parser/*/*-parser.terms.js
 dist/dev
+src/i18n/locales/*/*.md

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -37,3 +37,7 @@ To install and run this plugin:
 - clone this repo inside `.obsidian/plugins` of your dev vault
 - run `npm install` to install the necessary packages
 - run `npm run dev` to compile the project and reload obsidian either with hotreload or with the command.
+
+## Translations
+
+See [here](./src/i18n/locales/README.md) for more info.

--- a/esbuild.config.mts
+++ b/esbuild.config.mts
@@ -48,6 +48,7 @@ const args = {
 		"@lezer/highlight",
 		"@lezer/common",
 		"@lezer/lr",
+		"i18next",
 		"fs",
 		"path",
 		"os",

--- a/eslint.config.mts
+++ b/eslint.config.mts
@@ -26,9 +26,10 @@ export default defineConfig([
 
 			parser: tsParser,
 			parserOptions: {
-				projectService: {
-					allowDefaultProject: ["eslint.config.mts", "manifest.json"],
-				},
+				// projectService: {
+				// 	allowDefaultProject: ["eslint.config.mts", "manifest.json"],
+				// },
+				project: "./tsconfig.json",
 				tsconfigRootDir: __dirname,
 				extraFileExtensions: [".json"]
 			} satisfies ParserOptions,

--- a/package-lock.json
+++ b/package-lock.json
@@ -38,12 +38,13 @@
 				"eslint": "^9.39.2",
 				"eslint-plugin-obsidianmd": "^0.4.1",
 				"globals": "^17.3.0",
+				"i18next": "^26.4.0",
 				"jiti": "^2.7.0",
-				"obsidian": "^1.12.3",
+				"obsidian": "^1.13.1",
 				"obsidian-integration-testing": "^10.3.2",
 				"obsidian-typings": "^6.32.0",
 				"tslib": "2.3.1",
-				"typescript": "^5.9.3",
+				"typescript": "^6.0.3",
 				"vitest": "^4.1.11"
 			}
 		},
@@ -4263,6 +4264,21 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
+		"node_modules/eslint-plugin-obsidianmd/node_modules/obsidian": {
+			"version": "1.12.3",
+			"resolved": "https://registry.npmjs.org/obsidian/-/obsidian-1.12.3.tgz",
+			"integrity": "sha512-HxWqe763dOqzXjnNiHmAJTRERN8KILBSqxDSEqbeSr7W8R8Jxezzbca+nz1LiiqXnMpM8lV2jzAezw3CZ4xNUw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/codemirror": "5.60.8",
+				"moment": "2.29.4"
+			},
+			"peerDependencies": {
+				"@codemirror/state": "6.5.0",
+				"@codemirror/view": "6.38.6"
+			}
+		},
 		"node_modules/eslint-plugin-obsidianmd/node_modules/typescript": {
 			"version": "5.4.5",
 			"resolved": "https://registry.npmjs.org/typescript/-/typescript-5.4.5.tgz",
@@ -5225,6 +5241,35 @@
 			},
 			"engines": {
 				"node": ">= 14"
+			}
+		},
+		"node_modules/i18next": {
+			"version": "26.4.0",
+			"resolved": "https://registry.npmjs.org/i18next/-/i18next-26.4.0.tgz",
+			"integrity": "sha512-rsmK5bFqsD1AetSFSIa43wtNR4WpvvH4p0tLEsTxkC7QTrfdFm06nbQ95bh8Og4wwaCnUEcm9DVYL2cgxitiQg==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "individual",
+					"url": "https://www.locize.com/i18next"
+				},
+				{
+					"type": "individual",
+					"url": "https://www.i18next.com/how-to/faq#i18next-is-awesome.-how-can-i-support-the-project"
+				},
+				{
+					"type": "individual",
+					"url": "https://www.locize.com"
+				}
+			],
+			"license": "MIT",
+			"peerDependencies": {
+				"typescript": "^5 || ^6 || ^7"
+			},
+			"peerDependenciesMeta": {
+				"typescript": {
+					"optional": true
+				}
 			}
 		},
 		"node_modules/iconv-lite": {
@@ -6805,9 +6850,9 @@
 			}
 		},
 		"node_modules/obsidian": {
-			"version": "1.12.3",
-			"resolved": "https://registry.npmjs.org/obsidian/-/obsidian-1.12.3.tgz",
-			"integrity": "sha512-HxWqe763dOqzXjnNiHmAJTRERN8KILBSqxDSEqbeSr7W8R8Jxezzbca+nz1LiiqXnMpM8lV2jzAezw3CZ4xNUw==",
+			"version": "1.13.1",
+			"resolved": "https://registry.npmjs.org/obsidian/-/obsidian-1.13.1.tgz",
+			"integrity": "sha512-qtTEA2pmhJzhuhJqzbBFRYhpIOqvW+krDYjtFynv66KbxBbumHBlsJfWw3I4jtnK/6fZwbQhCrmmDdRwXmX56w==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -8557,9 +8602,9 @@
 			"license": "MIT"
 		},
 		"node_modules/typescript": {
-			"version": "5.9.3",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-			"integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+			"version": "6.0.3",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+			"integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
 			"devOptional": true,
 			"license": "Apache-2.0",
 			"bin": {
@@ -12190,6 +12235,16 @@
 					"integrity": "sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==",
 					"dev": true
 				},
+				"obsidian": {
+					"version": "1.12.3",
+					"resolved": "https://registry.npmjs.org/obsidian/-/obsidian-1.12.3.tgz",
+					"integrity": "sha512-HxWqe763dOqzXjnNiHmAJTRERN8KILBSqxDSEqbeSr7W8R8Jxezzbca+nz1LiiqXnMpM8lV2jzAezw3CZ4xNUw==",
+					"dev": true,
+					"requires": {
+						"@types/codemirror": "5.60.8",
+						"moment": "2.29.4"
+					}
+				},
 				"typescript": {
 					"version": "5.4.5",
 					"resolved": "https://registry.npmjs.org/typescript/-/typescript-5.4.5.tgz",
@@ -12796,6 +12851,13 @@
 				"agent-base": "^7.1.2",
 				"debug": "4"
 			}
+		},
+		"i18next": {
+			"version": "26.4.0",
+			"resolved": "https://registry.npmjs.org/i18next/-/i18next-26.4.0.tgz",
+			"integrity": "sha512-rsmK5bFqsD1AetSFSIa43wtNR4WpvvH4p0tLEsTxkC7QTrfdFm06nbQ95bh8Og4wwaCnUEcm9DVYL2cgxitiQg==",
+			"dev": true,
+			"requires": {}
 		},
 		"iconv-lite": {
 			"version": "0.6.3",
@@ -13763,9 +13825,9 @@
 			}
 		},
 		"obsidian": {
-			"version": "1.12.3",
-			"resolved": "https://registry.npmjs.org/obsidian/-/obsidian-1.12.3.tgz",
-			"integrity": "sha512-HxWqe763dOqzXjnNiHmAJTRERN8KILBSqxDSEqbeSr7W8R8Jxezzbca+nz1LiiqXnMpM8lV2jzAezw3CZ4xNUw==",
+			"version": "1.13.1",
+			"resolved": "https://registry.npmjs.org/obsidian/-/obsidian-1.13.1.tgz",
+			"integrity": "sha512-qtTEA2pmhJzhuhJqzbBFRYhpIOqvW+krDYjtFynv66KbxBbumHBlsJfWw3I4jtnK/6fZwbQhCrmmDdRwXmX56w==",
 			"dev": true,
 			"requires": {
 				"@types/codemirror": "5.60.8",
@@ -14934,9 +14996,9 @@
 			"dev": true
 		},
 		"typescript": {
-			"version": "5.9.3",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-			"integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+			"version": "6.0.3",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+			"integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
 			"devOptional": true
 		},
 		"typescript-eslint": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -43,8 +43,11 @@
 				"obsidian": "^1.13.1",
 				"obsidian-integration-testing": "^10.3.2",
 				"obsidian-typings": "^6.32.0",
+				"remark-parse": "^11.0.0",
+				"remark-stringify": "^11.0.0",
 				"tslib": "2.3.1",
 				"typescript": "^6.0.3",
+				"unified": "^11.0.5",
 				"vitest": "^4.1.11"
 			}
 		},
@@ -1334,6 +1337,16 @@
 				"@types/tern": "*"
 			}
 		},
+		"node_modules/@types/debug": {
+			"version": "4.1.13",
+			"resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.13.tgz",
+			"integrity": "sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/ms": "*"
+			}
+		},
 		"node_modules/@types/deep-eql": {
 			"version": "4.0.2",
 			"resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
@@ -1373,6 +1386,23 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/@types/mdast": {
+			"version": "4.0.4",
+			"resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-4.0.4.tgz",
+			"integrity": "sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/unist": "*"
+			}
+		},
+		"node_modules/@types/ms": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/@types/ms/-/ms-2.1.0.tgz",
+			"integrity": "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/@types/node": {
 			"version": "22.20.1",
 			"resolved": "https://registry.npmjs.org/@types/node/-/node-22.20.1.tgz",
@@ -1406,6 +1436,13 @@
 			"dependencies": {
 				"@types/estree": "*"
 			}
+		},
+		"node_modules/@types/unist": {
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
+			"integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/@types/which": {
 			"version": "2.0.2",
@@ -2600,6 +2637,17 @@
 				}
 			}
 		},
+		"node_modules/bail": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/bail/-/bail-2.0.2.tgz",
+			"integrity": "sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==",
+			"dev": true,
+			"license": "MIT",
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/wooorm"
+			}
+		},
 		"node_modules/balanced-match": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
@@ -2858,6 +2906,17 @@
 			},
 			"funding": {
 				"url": "https://github.com/chalk/chalk?sponsor=1"
+			}
+		},
+		"node_modules/character-entities": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/character-entities/-/character-entities-2.0.2.tgz",
+			"integrity": "sha512-shx7oQ0Awen/BRIdkjkvz54PnEEI/EjwXDSIZp86/KKdbafHh1Df/RYGBhn4hbe2+uKC9FnT5UCEdyPz3ai9hQ==",
+			"dev": true,
+			"license": "MIT",
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/wooorm"
 			}
 		},
 		"node_modules/cheerio": {
@@ -3251,6 +3310,20 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
+		"node_modules/decode-named-character-reference": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/decode-named-character-reference/-/decode-named-character-reference-1.3.0.tgz",
+			"integrity": "sha512-GtpQYB283KrPp6nRw50q3U9/VfOutZOe103qlN7BPP6Ad27xYnOIWv4lPzo8HCAL+mMZofJ9KEy30fq6MfaK6Q==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"character-entities": "^2.0.0"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/wooorm"
+			}
+		},
 		"node_modules/deep-is": {
 			"version": "0.1.4",
 			"resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
@@ -3313,6 +3386,16 @@
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
+		"node_modules/dequal": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+			"integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=6"
+			}
+		},
 		"node_modules/detect-libc": {
 			"version": "2.1.2",
 			"resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
@@ -3321,6 +3404,20 @@
 			"license": "Apache-2.0",
 			"engines": {
 				"node": ">=8"
+			}
+		},
+		"node_modules/devlop": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/devlop/-/devlop-1.1.0.tgz",
+			"integrity": "sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"dequal": "^2.0.0"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/wooorm"
 			}
 		},
 		"node_modules/devtools-protocol": {
@@ -4528,6 +4625,13 @@
 			"engines": {
 				"node": ">=12.0.0"
 			}
+		},
+		"node_modules/extend": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+			"integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/extract-zip": {
 			"version": "2.0.1",
@@ -6527,6 +6631,17 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/longest-streak": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/longest-streak/-/longest-streak-3.1.0.tgz",
+			"integrity": "sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==",
+			"dev": true,
+			"license": "MIT",
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/wooorm"
+			}
+		},
 		"node_modules/loose-envify": {
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
@@ -6566,6 +6681,545 @@
 			"engines": {
 				"node": ">= 0.4"
 			}
+		},
+		"node_modules/mdast-util-from-markdown": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/mdast-util-from-markdown/-/mdast-util-from-markdown-2.0.3.tgz",
+			"integrity": "sha512-W4mAWTvSlKvf8L6J+VN9yLSqQ9AOAAvHuoDAmPkz4dHf553m5gVj2ejadHJhoJmcmxEnOv6Pa8XJhpxE93kb8Q==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/mdast": "^4.0.0",
+				"@types/unist": "^3.0.0",
+				"decode-named-character-reference": "^1.0.0",
+				"devlop": "^1.0.0",
+				"mdast-util-to-string": "^4.0.0",
+				"micromark": "^4.0.0",
+				"micromark-util-decode-numeric-character-reference": "^2.0.0",
+				"micromark-util-decode-string": "^2.0.0",
+				"micromark-util-normalize-identifier": "^2.0.0",
+				"micromark-util-symbol": "^2.0.0",
+				"micromark-util-types": "^2.0.0",
+				"unist-util-stringify-position": "^4.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/mdast-util-phrasing": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/mdast-util-phrasing/-/mdast-util-phrasing-4.1.0.tgz",
+			"integrity": "sha512-TqICwyvJJpBwvGAMZjj4J2n0X8QWp21b9l0o7eXyVJ25YNWYbJDVIyD1bZXE6WtV6RmKJVYmQAKWa0zWOABz2w==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/mdast": "^4.0.0",
+				"unist-util-is": "^6.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/mdast-util-to-markdown": {
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/mdast-util-to-markdown/-/mdast-util-to-markdown-2.1.2.tgz",
+			"integrity": "sha512-xj68wMTvGXVOKonmog6LwyJKrYXZPvlwabaryTjLh9LuvovB/KAH+kvi8Gjj+7rJjsFi23nkUxRQv1KqSroMqA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/mdast": "^4.0.0",
+				"@types/unist": "^3.0.0",
+				"longest-streak": "^3.0.0",
+				"mdast-util-phrasing": "^4.0.0",
+				"mdast-util-to-string": "^4.0.0",
+				"micromark-util-classify-character": "^2.0.0",
+				"micromark-util-decode-string": "^2.0.0",
+				"unist-util-visit": "^5.0.0",
+				"zwitch": "^2.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/mdast-util-to-string": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/mdast-util-to-string/-/mdast-util-to-string-4.0.0.tgz",
+			"integrity": "sha512-0H44vDimn51F0YwvxSJSm0eCDOJTRlmN0R1yBh4HLj9wiV1Dn0QoXGbvFAWj2hSItVTlCmBF1hqKlIyUBVFLPg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/mdast": "^4.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/micromark": {
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/micromark/-/micromark-4.0.2.tgz",
+			"integrity": "sha512-zpe98Q6kvavpCr1NPVSCMebCKfD7CA2NqZ+rykeNhONIJBpc1tFKt9hucLGwha3jNTNI8lHpctWJWoimVF4PfA==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "GitHub Sponsors",
+					"url": "https://github.com/sponsors/unifiedjs"
+				},
+				{
+					"type": "OpenCollective",
+					"url": "https://opencollective.com/unified"
+				}
+			],
+			"license": "MIT",
+			"dependencies": {
+				"@types/debug": "^4.0.0",
+				"debug": "^4.0.0",
+				"decode-named-character-reference": "^1.0.0",
+				"devlop": "^1.0.0",
+				"micromark-core-commonmark": "^2.0.0",
+				"micromark-factory-space": "^2.0.0",
+				"micromark-util-character": "^2.0.0",
+				"micromark-util-chunked": "^2.0.0",
+				"micromark-util-combine-extensions": "^2.0.0",
+				"micromark-util-decode-numeric-character-reference": "^2.0.0",
+				"micromark-util-encode": "^2.0.0",
+				"micromark-util-normalize-identifier": "^2.0.0",
+				"micromark-util-resolve-all": "^2.0.0",
+				"micromark-util-sanitize-uri": "^2.0.0",
+				"micromark-util-subtokenize": "^2.0.0",
+				"micromark-util-symbol": "^2.0.0",
+				"micromark-util-types": "^2.0.0"
+			}
+		},
+		"node_modules/micromark-core-commonmark": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/micromark-core-commonmark/-/micromark-core-commonmark-2.0.3.tgz",
+			"integrity": "sha512-RDBrHEMSxVFLg6xvnXmb1Ayr2WzLAWjeSATAoxwKYJV94TeNavgoIdA0a9ytzDSVzBy2YKFK+emCPOEibLeCrg==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "GitHub Sponsors",
+					"url": "https://github.com/sponsors/unifiedjs"
+				},
+				{
+					"type": "OpenCollective",
+					"url": "https://opencollective.com/unified"
+				}
+			],
+			"license": "MIT",
+			"dependencies": {
+				"decode-named-character-reference": "^1.0.0",
+				"devlop": "^1.0.0",
+				"micromark-factory-destination": "^2.0.0",
+				"micromark-factory-label": "^2.0.0",
+				"micromark-factory-space": "^2.0.0",
+				"micromark-factory-title": "^2.0.0",
+				"micromark-factory-whitespace": "^2.0.0",
+				"micromark-util-character": "^2.0.0",
+				"micromark-util-chunked": "^2.0.0",
+				"micromark-util-classify-character": "^2.0.0",
+				"micromark-util-html-tag-name": "^2.0.0",
+				"micromark-util-normalize-identifier": "^2.0.0",
+				"micromark-util-resolve-all": "^2.0.0",
+				"micromark-util-subtokenize": "^2.0.0",
+				"micromark-util-symbol": "^2.0.0",
+				"micromark-util-types": "^2.0.0"
+			}
+		},
+		"node_modules/micromark-factory-destination": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/micromark-factory-destination/-/micromark-factory-destination-2.0.1.tgz",
+			"integrity": "sha512-Xe6rDdJlkmbFRExpTOmRj9N3MaWmbAgdpSrBQvCFqhezUn4AHqJHbaEnfbVYYiexVSs//tqOdY/DxhjdCiJnIA==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "GitHub Sponsors",
+					"url": "https://github.com/sponsors/unifiedjs"
+				},
+				{
+					"type": "OpenCollective",
+					"url": "https://opencollective.com/unified"
+				}
+			],
+			"license": "MIT",
+			"dependencies": {
+				"micromark-util-character": "^2.0.0",
+				"micromark-util-symbol": "^2.0.0",
+				"micromark-util-types": "^2.0.0"
+			}
+		},
+		"node_modules/micromark-factory-label": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/micromark-factory-label/-/micromark-factory-label-2.0.1.tgz",
+			"integrity": "sha512-VFMekyQExqIW7xIChcXn4ok29YE3rnuyveW3wZQWWqF4Nv9Wk5rgJ99KzPvHjkmPXF93FXIbBp6YdW3t71/7Vg==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "GitHub Sponsors",
+					"url": "https://github.com/sponsors/unifiedjs"
+				},
+				{
+					"type": "OpenCollective",
+					"url": "https://opencollective.com/unified"
+				}
+			],
+			"license": "MIT",
+			"dependencies": {
+				"devlop": "^1.0.0",
+				"micromark-util-character": "^2.0.0",
+				"micromark-util-symbol": "^2.0.0",
+				"micromark-util-types": "^2.0.0"
+			}
+		},
+		"node_modules/micromark-factory-space": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/micromark-factory-space/-/micromark-factory-space-2.0.1.tgz",
+			"integrity": "sha512-zRkxjtBxxLd2Sc0d+fbnEunsTj46SWXgXciZmHq0kDYGnck/ZSGj9/wULTV95uoeYiK5hRXP2mJ98Uo4cq/LQg==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "GitHub Sponsors",
+					"url": "https://github.com/sponsors/unifiedjs"
+				},
+				{
+					"type": "OpenCollective",
+					"url": "https://opencollective.com/unified"
+				}
+			],
+			"license": "MIT",
+			"dependencies": {
+				"micromark-util-character": "^2.0.0",
+				"micromark-util-types": "^2.0.0"
+			}
+		},
+		"node_modules/micromark-factory-title": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/micromark-factory-title/-/micromark-factory-title-2.0.1.tgz",
+			"integrity": "sha512-5bZ+3CjhAd9eChYTHsjy6TGxpOFSKgKKJPJxr293jTbfry2KDoWkhBb6TcPVB4NmzaPhMs1Frm9AZH7OD4Cjzw==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "GitHub Sponsors",
+					"url": "https://github.com/sponsors/unifiedjs"
+				},
+				{
+					"type": "OpenCollective",
+					"url": "https://opencollective.com/unified"
+				}
+			],
+			"license": "MIT",
+			"dependencies": {
+				"micromark-factory-space": "^2.0.0",
+				"micromark-util-character": "^2.0.0",
+				"micromark-util-symbol": "^2.0.0",
+				"micromark-util-types": "^2.0.0"
+			}
+		},
+		"node_modules/micromark-factory-whitespace": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/micromark-factory-whitespace/-/micromark-factory-whitespace-2.0.1.tgz",
+			"integrity": "sha512-Ob0nuZ3PKt/n0hORHyvoD9uZhr+Za8sFoP+OnMcnWK5lngSzALgQYKMr9RJVOWLqQYuyn6ulqGWSXdwf6F80lQ==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "GitHub Sponsors",
+					"url": "https://github.com/sponsors/unifiedjs"
+				},
+				{
+					"type": "OpenCollective",
+					"url": "https://opencollective.com/unified"
+				}
+			],
+			"license": "MIT",
+			"dependencies": {
+				"micromark-factory-space": "^2.0.0",
+				"micromark-util-character": "^2.0.0",
+				"micromark-util-symbol": "^2.0.0",
+				"micromark-util-types": "^2.0.0"
+			}
+		},
+		"node_modules/micromark-util-character": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/micromark-util-character/-/micromark-util-character-2.1.1.tgz",
+			"integrity": "sha512-wv8tdUTJ3thSFFFJKtpYKOYiGP2+v96Hvk4Tu8KpCAsTMs6yi+nVmGh1syvSCsaxz45J6Jbw+9DD6g97+NV67Q==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "GitHub Sponsors",
+					"url": "https://github.com/sponsors/unifiedjs"
+				},
+				{
+					"type": "OpenCollective",
+					"url": "https://opencollective.com/unified"
+				}
+			],
+			"license": "MIT",
+			"dependencies": {
+				"micromark-util-symbol": "^2.0.0",
+				"micromark-util-types": "^2.0.0"
+			}
+		},
+		"node_modules/micromark-util-chunked": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/micromark-util-chunked/-/micromark-util-chunked-2.0.1.tgz",
+			"integrity": "sha512-QUNFEOPELfmvv+4xiNg2sRYeS/P84pTW0TCgP5zc9FpXetHY0ab7SxKyAQCNCc1eK0459uoLI1y5oO5Vc1dbhA==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "GitHub Sponsors",
+					"url": "https://github.com/sponsors/unifiedjs"
+				},
+				{
+					"type": "OpenCollective",
+					"url": "https://opencollective.com/unified"
+				}
+			],
+			"license": "MIT",
+			"dependencies": {
+				"micromark-util-symbol": "^2.0.0"
+			}
+		},
+		"node_modules/micromark-util-classify-character": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/micromark-util-classify-character/-/micromark-util-classify-character-2.0.1.tgz",
+			"integrity": "sha512-K0kHzM6afW/MbeWYWLjoHQv1sgg2Q9EccHEDzSkxiP/EaagNzCm7T/WMKZ3rjMbvIpvBiZgwR3dKMygtA4mG1Q==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "GitHub Sponsors",
+					"url": "https://github.com/sponsors/unifiedjs"
+				},
+				{
+					"type": "OpenCollective",
+					"url": "https://opencollective.com/unified"
+				}
+			],
+			"license": "MIT",
+			"dependencies": {
+				"micromark-util-character": "^2.0.0",
+				"micromark-util-symbol": "^2.0.0",
+				"micromark-util-types": "^2.0.0"
+			}
+		},
+		"node_modules/micromark-util-combine-extensions": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/micromark-util-combine-extensions/-/micromark-util-combine-extensions-2.0.1.tgz",
+			"integrity": "sha512-OnAnH8Ujmy59JcyZw8JSbK9cGpdVY44NKgSM7E9Eh7DiLS2E9RNQf0dONaGDzEG9yjEl5hcqeIsj4hfRkLH/Bg==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "GitHub Sponsors",
+					"url": "https://github.com/sponsors/unifiedjs"
+				},
+				{
+					"type": "OpenCollective",
+					"url": "https://opencollective.com/unified"
+				}
+			],
+			"license": "MIT",
+			"dependencies": {
+				"micromark-util-chunked": "^2.0.0",
+				"micromark-util-types": "^2.0.0"
+			}
+		},
+		"node_modules/micromark-util-decode-numeric-character-reference": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/micromark-util-decode-numeric-character-reference/-/micromark-util-decode-numeric-character-reference-2.0.2.tgz",
+			"integrity": "sha512-ccUbYk6CwVdkmCQMyr64dXz42EfHGkPQlBj5p7YVGzq8I7CtjXZJrubAYezf7Rp+bjPseiROqe7G6foFd+lEuw==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "GitHub Sponsors",
+					"url": "https://github.com/sponsors/unifiedjs"
+				},
+				{
+					"type": "OpenCollective",
+					"url": "https://opencollective.com/unified"
+				}
+			],
+			"license": "MIT",
+			"dependencies": {
+				"micromark-util-symbol": "^2.0.0"
+			}
+		},
+		"node_modules/micromark-util-decode-string": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/micromark-util-decode-string/-/micromark-util-decode-string-2.0.1.tgz",
+			"integrity": "sha512-nDV/77Fj6eH1ynwscYTOsbK7rR//Uj0bZXBwJZRfaLEJ1iGBR6kIfNmlNqaqJf649EP0F3NWNdeJi03elllNUQ==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "GitHub Sponsors",
+					"url": "https://github.com/sponsors/unifiedjs"
+				},
+				{
+					"type": "OpenCollective",
+					"url": "https://opencollective.com/unified"
+				}
+			],
+			"license": "MIT",
+			"dependencies": {
+				"decode-named-character-reference": "^1.0.0",
+				"micromark-util-character": "^2.0.0",
+				"micromark-util-decode-numeric-character-reference": "^2.0.0",
+				"micromark-util-symbol": "^2.0.0"
+			}
+		},
+		"node_modules/micromark-util-encode": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/micromark-util-encode/-/micromark-util-encode-2.0.1.tgz",
+			"integrity": "sha512-c3cVx2y4KqUnwopcO9b/SCdo2O67LwJJ/UyqGfbigahfegL9myoEFoDYZgkT7f36T0bLrM9hZTAaAyH+PCAXjw==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "GitHub Sponsors",
+					"url": "https://github.com/sponsors/unifiedjs"
+				},
+				{
+					"type": "OpenCollective",
+					"url": "https://opencollective.com/unified"
+				}
+			],
+			"license": "MIT"
+		},
+		"node_modules/micromark-util-html-tag-name": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/micromark-util-html-tag-name/-/micromark-util-html-tag-name-2.0.1.tgz",
+			"integrity": "sha512-2cNEiYDhCWKI+Gs9T0Tiysk136SnR13hhO8yW6BGNyhOC4qYFnwF1nKfD3HFAIXA5c45RrIG1ub11GiXeYd1xA==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "GitHub Sponsors",
+					"url": "https://github.com/sponsors/unifiedjs"
+				},
+				{
+					"type": "OpenCollective",
+					"url": "https://opencollective.com/unified"
+				}
+			],
+			"license": "MIT"
+		},
+		"node_modules/micromark-util-normalize-identifier": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/micromark-util-normalize-identifier/-/micromark-util-normalize-identifier-2.0.1.tgz",
+			"integrity": "sha512-sxPqmo70LyARJs0w2UclACPUUEqltCkJ6PhKdMIDuJ3gSf/Q+/GIe3WKl0Ijb/GyH9lOpUkRAO2wp0GVkLvS9Q==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "GitHub Sponsors",
+					"url": "https://github.com/sponsors/unifiedjs"
+				},
+				{
+					"type": "OpenCollective",
+					"url": "https://opencollective.com/unified"
+				}
+			],
+			"license": "MIT",
+			"dependencies": {
+				"micromark-util-symbol": "^2.0.0"
+			}
+		},
+		"node_modules/micromark-util-resolve-all": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/micromark-util-resolve-all/-/micromark-util-resolve-all-2.0.1.tgz",
+			"integrity": "sha512-VdQyxFWFT2/FGJgwQnJYbe1jjQoNTS4RjglmSjTUlpUMa95Htx9NHeYW4rGDJzbjvCsl9eLjMQwGeElsqmzcHg==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "GitHub Sponsors",
+					"url": "https://github.com/sponsors/unifiedjs"
+				},
+				{
+					"type": "OpenCollective",
+					"url": "https://opencollective.com/unified"
+				}
+			],
+			"license": "MIT",
+			"dependencies": {
+				"micromark-util-types": "^2.0.0"
+			}
+		},
+		"node_modules/micromark-util-sanitize-uri": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/micromark-util-sanitize-uri/-/micromark-util-sanitize-uri-2.0.1.tgz",
+			"integrity": "sha512-9N9IomZ/YuGGZZmQec1MbgxtlgougxTodVwDzzEouPKo3qFWvymFHWcnDi2vzV1ff6kas9ucW+o3yzJK9YB1AQ==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "GitHub Sponsors",
+					"url": "https://github.com/sponsors/unifiedjs"
+				},
+				{
+					"type": "OpenCollective",
+					"url": "https://opencollective.com/unified"
+				}
+			],
+			"license": "MIT",
+			"dependencies": {
+				"micromark-util-character": "^2.0.0",
+				"micromark-util-encode": "^2.0.0",
+				"micromark-util-symbol": "^2.0.0"
+			}
+		},
+		"node_modules/micromark-util-subtokenize": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/micromark-util-subtokenize/-/micromark-util-subtokenize-2.1.0.tgz",
+			"integrity": "sha512-XQLu552iSctvnEcgXw6+Sx75GflAPNED1qx7eBJ+wydBb2KCbRZe+NwvIEEMM83uml1+2WSXpBAcp9IUCgCYWA==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "GitHub Sponsors",
+					"url": "https://github.com/sponsors/unifiedjs"
+				},
+				{
+					"type": "OpenCollective",
+					"url": "https://opencollective.com/unified"
+				}
+			],
+			"license": "MIT",
+			"dependencies": {
+				"devlop": "^1.0.0",
+				"micromark-util-chunked": "^2.0.0",
+				"micromark-util-symbol": "^2.0.0",
+				"micromark-util-types": "^2.0.0"
+			}
+		},
+		"node_modules/micromark-util-symbol": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/micromark-util-symbol/-/micromark-util-symbol-2.0.1.tgz",
+			"integrity": "sha512-vs5t8Apaud9N28kgCrRUdEed4UJ+wWNvicHLPxCa9ENlYuAY31M0ETy5y1vA33YoNPDFTghEbnh6efaE8h4x0Q==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "GitHub Sponsors",
+					"url": "https://github.com/sponsors/unifiedjs"
+				},
+				{
+					"type": "OpenCollective",
+					"url": "https://opencollective.com/unified"
+				}
+			],
+			"license": "MIT"
+		},
+		"node_modules/micromark-util-types": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/micromark-util-types/-/micromark-util-types-2.0.2.tgz",
+			"integrity": "sha512-Yw0ECSpJoViF1qTU4DC6NwtC4aWGt1EkzaQB8KPPyCRR8z9TWeV0HbEFGTO+ZY1wB22zmxnJqhPyTpOVCpeHTA==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "GitHub Sponsors",
+					"url": "https://github.com/sponsors/unifiedjs"
+				},
+				{
+					"type": "OpenCollective",
+					"url": "https://opencollective.com/unified"
+				}
+			],
+			"license": "MIT"
 		},
 		"node_modules/minimatch": {
 			"version": "3.1.2",
@@ -7400,6 +8054,39 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/remark-parse": {
+			"version": "11.0.0",
+			"resolved": "https://registry.npmjs.org/remark-parse/-/remark-parse-11.0.0.tgz",
+			"integrity": "sha512-FCxlKLNGknS5ba/1lmpYijMUzX2esxW5xQqjWxw2eHFfS2MSdaHVINFmhjo+qN1WhZhNimq0dZATN9pH0IDrpA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/mdast": "^4.0.0",
+				"mdast-util-from-markdown": "^2.0.0",
+				"micromark-util-types": "^2.0.0",
+				"unified": "^11.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/remark-stringify": {
+			"version": "11.0.0",
+			"resolved": "https://registry.npmjs.org/remark-stringify/-/remark-stringify-11.0.0.tgz",
+			"integrity": "sha512-1OSmLd3awB/t8qdoEOMazZkNsfVTeY4fTsgzcQFdXNq8ToTN4ZGwrMnlda4K6smTFKD+GRV6O48i6Z4iKgPPpw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/mdast": "^4.0.0",
+				"mdast-util-to-markdown": "^2.0.0",
+				"unified": "^11.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
 			}
 		},
 		"node_modules/require-directory": {
@@ -8442,6 +9129,17 @@
 				"url": "https://github.com/sponsors/ota-meshi"
 			}
 		},
+		"node_modules/trough": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/trough/-/trough-2.2.0.tgz",
+			"integrity": "sha512-tmMpK00BjZiUyVyvrBK7knerNgmgvcV/KLVyuma/SC+TQN167GrMRciANTz09+k3zW8L8t60jWO1GpfkZdjTaw==",
+			"dev": true,
+			"license": "MIT",
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/wooorm"
+			}
+		},
 		"node_modules/ts-api-utils": {
 			"version": "2.5.0",
 			"resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.5.0.tgz",
@@ -8675,6 +9373,85 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/unified": {
+			"version": "11.0.5",
+			"resolved": "https://registry.npmjs.org/unified/-/unified-11.0.5.tgz",
+			"integrity": "sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/unist": "^3.0.0",
+				"bail": "^2.0.0",
+				"devlop": "^1.0.0",
+				"extend": "^3.0.0",
+				"is-plain-obj": "^4.0.0",
+				"trough": "^2.0.0",
+				"vfile": "^6.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/unist-util-is": {
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-6.0.1.tgz",
+			"integrity": "sha512-LsiILbtBETkDz8I9p1dQ0uyRUWuaQzd/cuEeS1hoRSyW5E5XGmTzlwY1OrNzzakGowI9Dr/I8HVaw4hTtnxy8g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/unist": "^3.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/unist-util-stringify-position": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-4.0.0.tgz",
+			"integrity": "sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/unist": "^3.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/unist-util-visit": {
+			"version": "5.1.0",
+			"resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-5.1.0.tgz",
+			"integrity": "sha512-m+vIdyeCOpdr/QeQCu2EzxX/ohgS8KbnPDgFni4dQsfSCtpz8UqDyY5GjRru8PDKuYn7Fq19j1CQ+nJSsGKOzg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/unist": "^3.0.0",
+				"unist-util-is": "^6.0.0",
+				"unist-util-visit-parents": "^6.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/unist-util-visit-parents": {
+			"version": "6.0.2",
+			"resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-6.0.2.tgz",
+			"integrity": "sha512-goh1s1TBrqSqukSc8wrjwWhL0hiJxgA8m4kFxGlQ+8FYQ3C/m11FcTs4YYem7V664AhHVvgoQLk890Ssdsr2IQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/unist": "^3.0.0",
+				"unist-util-is": "^6.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
 		"node_modules/uri-js": {
 			"version": "4.4.1",
 			"resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
@@ -8720,6 +9497,36 @@
 				"typescript": {
 					"optional": true
 				}
+			}
+		},
+		"node_modules/vfile": {
+			"version": "6.0.3",
+			"resolved": "https://registry.npmjs.org/vfile/-/vfile-6.0.3.tgz",
+			"integrity": "sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/unist": "^3.0.0",
+				"vfile-message": "^4.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/vfile-message": {
+			"version": "4.0.3",
+			"resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-4.0.3.tgz",
+			"integrity": "sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/unist": "^3.0.0",
+				"unist-util-stringify-position": "^4.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
 			}
 		},
 		"node_modules/vitest": {
@@ -9491,6 +10298,17 @@
 			"funding": {
 				"url": "https://github.com/sponsors/colinhacks"
 			}
+		},
+		"node_modules/zwitch": {
+			"version": "2.0.4",
+			"resolved": "https://registry.npmjs.org/zwitch/-/zwitch-2.0.4.tgz",
+			"integrity": "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==",
+			"dev": true,
+			"license": "MIT",
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/wooorm"
+			}
 		}
 	},
 	"dependencies": {
@@ -10225,6 +11043,15 @@
 				"@types/tern": "*"
 			}
 		},
+		"@types/debug": {
+			"version": "4.1.13",
+			"resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.13.tgz",
+			"integrity": "sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw==",
+			"dev": true,
+			"requires": {
+				"@types/ms": "*"
+			}
+		},
 		"@types/deep-eql": {
 			"version": "4.0.2",
 			"resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
@@ -10259,6 +11086,21 @@
 			"integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==",
 			"dev": true
 		},
+		"@types/mdast": {
+			"version": "4.0.4",
+			"resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-4.0.4.tgz",
+			"integrity": "sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==",
+			"dev": true,
+			"requires": {
+				"@types/unist": "*"
+			}
+		},
+		"@types/ms": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/@types/ms/-/ms-2.1.0.tgz",
+			"integrity": "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==",
+			"dev": true
+		},
 		"@types/node": {
 			"version": "22.20.1",
 			"resolved": "https://registry.npmjs.org/@types/node/-/node-22.20.1.tgz",
@@ -10290,6 +11132,12 @@
 			"requires": {
 				"@types/estree": "*"
 			}
+		},
+		"@types/unist": {
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
+			"integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
+			"dev": true
 		},
 		"@types/which": {
 			"version": "2.0.2",
@@ -11095,6 +11943,12 @@
 			"dev": true,
 			"requires": {}
 		},
+		"bail": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/bail/-/bail-2.0.2.tgz",
+			"integrity": "sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==",
+			"dev": true
+		},
 		"balanced-match": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
@@ -11244,6 +12098,12 @@
 				"ansi-styles": "^4.1.0",
 				"supports-color": "^7.1.0"
 			}
+		},
+		"character-entities": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/character-entities/-/character-entities-2.0.2.tgz",
+			"integrity": "sha512-shx7oQ0Awen/BRIdkjkvz54PnEEI/EjwXDSIZp86/KKdbafHh1Df/RYGBhn4hbe2+uKC9FnT5UCEdyPz3ai9hQ==",
+			"dev": true
 		},
 		"cheerio": {
 			"version": "1.2.0",
@@ -11514,6 +12374,15 @@
 			"integrity": "sha512-G7Cqgaelq68XHJNGlZ7lrNQyhZGsFqpwtGFexqUv4IQdjKoSYF7ipZ9UuTJZUSQXFj/XaoBLuEVIVqr8EJngEQ==",
 			"dev": true
 		},
+		"decode-named-character-reference": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/decode-named-character-reference/-/decode-named-character-reference-1.3.0.tgz",
+			"integrity": "sha512-GtpQYB283KrPp6nRw50q3U9/VfOutZOe103qlN7BPP6Ad27xYnOIWv4lPzo8HCAL+mMZofJ9KEy30fq6MfaK6Q==",
+			"dev": true,
+			"requires": {
+				"character-entities": "^2.0.0"
+			}
+		},
 		"deep-is": {
 			"version": "0.1.4",
 			"resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
@@ -11548,11 +12417,26 @@
 				"object-keys": "^1.1.1"
 			}
 		},
+		"dequal": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+			"integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+			"dev": true
+		},
 		"detect-libc": {
 			"version": "2.1.2",
 			"resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
 			"integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
 			"dev": true
+		},
+		"devlop": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/devlop/-/devlop-1.1.0.tgz",
+			"integrity": "sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==",
+			"dev": true,
+			"requires": {
+				"dequal": "^2.0.0"
+			}
 		},
 		"devtools-protocol": {
 			"version": "0.0.1666840",
@@ -12401,6 +13285,12 @@
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.4.0.tgz",
 			"integrity": "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==",
+			"dev": true
+		},
+		"extend": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+			"integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
 			"dev": true
 		},
 		"extract-zip": {
@@ -13611,6 +14501,12 @@
 			"integrity": "sha512-WpG9CcFAOjz/FtNht+QJeGpvVl/cdR6P0z6OcXSkr8wFJOsV2GRj2j10JLfjuA4aYkcKCNIEqRGCyTife9R8/g==",
 			"dev": true
 		},
+		"longest-streak": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/longest-streak/-/longest-streak-3.1.0.tgz",
+			"integrity": "sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==",
+			"dev": true
+		},
 		"loose-envify": {
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
@@ -13639,6 +14535,294 @@
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
 			"integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+			"dev": true
+		},
+		"mdast-util-from-markdown": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/mdast-util-from-markdown/-/mdast-util-from-markdown-2.0.3.tgz",
+			"integrity": "sha512-W4mAWTvSlKvf8L6J+VN9yLSqQ9AOAAvHuoDAmPkz4dHf553m5gVj2ejadHJhoJmcmxEnOv6Pa8XJhpxE93kb8Q==",
+			"dev": true,
+			"requires": {
+				"@types/mdast": "^4.0.0",
+				"@types/unist": "^3.0.0",
+				"decode-named-character-reference": "^1.0.0",
+				"devlop": "^1.0.0",
+				"mdast-util-to-string": "^4.0.0",
+				"micromark": "^4.0.0",
+				"micromark-util-decode-numeric-character-reference": "^2.0.0",
+				"micromark-util-decode-string": "^2.0.0",
+				"micromark-util-normalize-identifier": "^2.0.0",
+				"micromark-util-symbol": "^2.0.0",
+				"micromark-util-types": "^2.0.0",
+				"unist-util-stringify-position": "^4.0.0"
+			}
+		},
+		"mdast-util-phrasing": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/mdast-util-phrasing/-/mdast-util-phrasing-4.1.0.tgz",
+			"integrity": "sha512-TqICwyvJJpBwvGAMZjj4J2n0X8QWp21b9l0o7eXyVJ25YNWYbJDVIyD1bZXE6WtV6RmKJVYmQAKWa0zWOABz2w==",
+			"dev": true,
+			"requires": {
+				"@types/mdast": "^4.0.0",
+				"unist-util-is": "^6.0.0"
+			}
+		},
+		"mdast-util-to-markdown": {
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/mdast-util-to-markdown/-/mdast-util-to-markdown-2.1.2.tgz",
+			"integrity": "sha512-xj68wMTvGXVOKonmog6LwyJKrYXZPvlwabaryTjLh9LuvovB/KAH+kvi8Gjj+7rJjsFi23nkUxRQv1KqSroMqA==",
+			"dev": true,
+			"requires": {
+				"@types/mdast": "^4.0.0",
+				"@types/unist": "^3.0.0",
+				"longest-streak": "^3.0.0",
+				"mdast-util-phrasing": "^4.0.0",
+				"mdast-util-to-string": "^4.0.0",
+				"micromark-util-classify-character": "^2.0.0",
+				"micromark-util-decode-string": "^2.0.0",
+				"unist-util-visit": "^5.0.0",
+				"zwitch": "^2.0.0"
+			}
+		},
+		"mdast-util-to-string": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/mdast-util-to-string/-/mdast-util-to-string-4.0.0.tgz",
+			"integrity": "sha512-0H44vDimn51F0YwvxSJSm0eCDOJTRlmN0R1yBh4HLj9wiV1Dn0QoXGbvFAWj2hSItVTlCmBF1hqKlIyUBVFLPg==",
+			"dev": true,
+			"requires": {
+				"@types/mdast": "^4.0.0"
+			}
+		},
+		"micromark": {
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/micromark/-/micromark-4.0.2.tgz",
+			"integrity": "sha512-zpe98Q6kvavpCr1NPVSCMebCKfD7CA2NqZ+rykeNhONIJBpc1tFKt9hucLGwha3jNTNI8lHpctWJWoimVF4PfA==",
+			"dev": true,
+			"requires": {
+				"@types/debug": "^4.0.0",
+				"debug": "^4.0.0",
+				"decode-named-character-reference": "^1.0.0",
+				"devlop": "^1.0.0",
+				"micromark-core-commonmark": "^2.0.0",
+				"micromark-factory-space": "^2.0.0",
+				"micromark-util-character": "^2.0.0",
+				"micromark-util-chunked": "^2.0.0",
+				"micromark-util-combine-extensions": "^2.0.0",
+				"micromark-util-decode-numeric-character-reference": "^2.0.0",
+				"micromark-util-encode": "^2.0.0",
+				"micromark-util-normalize-identifier": "^2.0.0",
+				"micromark-util-resolve-all": "^2.0.0",
+				"micromark-util-sanitize-uri": "^2.0.0",
+				"micromark-util-subtokenize": "^2.0.0",
+				"micromark-util-symbol": "^2.0.0",
+				"micromark-util-types": "^2.0.0"
+			}
+		},
+		"micromark-core-commonmark": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/micromark-core-commonmark/-/micromark-core-commonmark-2.0.3.tgz",
+			"integrity": "sha512-RDBrHEMSxVFLg6xvnXmb1Ayr2WzLAWjeSATAoxwKYJV94TeNavgoIdA0a9ytzDSVzBy2YKFK+emCPOEibLeCrg==",
+			"dev": true,
+			"requires": {
+				"decode-named-character-reference": "^1.0.0",
+				"devlop": "^1.0.0",
+				"micromark-factory-destination": "^2.0.0",
+				"micromark-factory-label": "^2.0.0",
+				"micromark-factory-space": "^2.0.0",
+				"micromark-factory-title": "^2.0.0",
+				"micromark-factory-whitespace": "^2.0.0",
+				"micromark-util-character": "^2.0.0",
+				"micromark-util-chunked": "^2.0.0",
+				"micromark-util-classify-character": "^2.0.0",
+				"micromark-util-html-tag-name": "^2.0.0",
+				"micromark-util-normalize-identifier": "^2.0.0",
+				"micromark-util-resolve-all": "^2.0.0",
+				"micromark-util-subtokenize": "^2.0.0",
+				"micromark-util-symbol": "^2.0.0",
+				"micromark-util-types": "^2.0.0"
+			}
+		},
+		"micromark-factory-destination": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/micromark-factory-destination/-/micromark-factory-destination-2.0.1.tgz",
+			"integrity": "sha512-Xe6rDdJlkmbFRExpTOmRj9N3MaWmbAgdpSrBQvCFqhezUn4AHqJHbaEnfbVYYiexVSs//tqOdY/DxhjdCiJnIA==",
+			"dev": true,
+			"requires": {
+				"micromark-util-character": "^2.0.0",
+				"micromark-util-symbol": "^2.0.0",
+				"micromark-util-types": "^2.0.0"
+			}
+		},
+		"micromark-factory-label": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/micromark-factory-label/-/micromark-factory-label-2.0.1.tgz",
+			"integrity": "sha512-VFMekyQExqIW7xIChcXn4ok29YE3rnuyveW3wZQWWqF4Nv9Wk5rgJ99KzPvHjkmPXF93FXIbBp6YdW3t71/7Vg==",
+			"dev": true,
+			"requires": {
+				"devlop": "^1.0.0",
+				"micromark-util-character": "^2.0.0",
+				"micromark-util-symbol": "^2.0.0",
+				"micromark-util-types": "^2.0.0"
+			}
+		},
+		"micromark-factory-space": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/micromark-factory-space/-/micromark-factory-space-2.0.1.tgz",
+			"integrity": "sha512-zRkxjtBxxLd2Sc0d+fbnEunsTj46SWXgXciZmHq0kDYGnck/ZSGj9/wULTV95uoeYiK5hRXP2mJ98Uo4cq/LQg==",
+			"dev": true,
+			"requires": {
+				"micromark-util-character": "^2.0.0",
+				"micromark-util-types": "^2.0.0"
+			}
+		},
+		"micromark-factory-title": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/micromark-factory-title/-/micromark-factory-title-2.0.1.tgz",
+			"integrity": "sha512-5bZ+3CjhAd9eChYTHsjy6TGxpOFSKgKKJPJxr293jTbfry2KDoWkhBb6TcPVB4NmzaPhMs1Frm9AZH7OD4Cjzw==",
+			"dev": true,
+			"requires": {
+				"micromark-factory-space": "^2.0.0",
+				"micromark-util-character": "^2.0.0",
+				"micromark-util-symbol": "^2.0.0",
+				"micromark-util-types": "^2.0.0"
+			}
+		},
+		"micromark-factory-whitespace": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/micromark-factory-whitespace/-/micromark-factory-whitespace-2.0.1.tgz",
+			"integrity": "sha512-Ob0nuZ3PKt/n0hORHyvoD9uZhr+Za8sFoP+OnMcnWK5lngSzALgQYKMr9RJVOWLqQYuyn6ulqGWSXdwf6F80lQ==",
+			"dev": true,
+			"requires": {
+				"micromark-factory-space": "^2.0.0",
+				"micromark-util-character": "^2.0.0",
+				"micromark-util-symbol": "^2.0.0",
+				"micromark-util-types": "^2.0.0"
+			}
+		},
+		"micromark-util-character": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/micromark-util-character/-/micromark-util-character-2.1.1.tgz",
+			"integrity": "sha512-wv8tdUTJ3thSFFFJKtpYKOYiGP2+v96Hvk4Tu8KpCAsTMs6yi+nVmGh1syvSCsaxz45J6Jbw+9DD6g97+NV67Q==",
+			"dev": true,
+			"requires": {
+				"micromark-util-symbol": "^2.0.0",
+				"micromark-util-types": "^2.0.0"
+			}
+		},
+		"micromark-util-chunked": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/micromark-util-chunked/-/micromark-util-chunked-2.0.1.tgz",
+			"integrity": "sha512-QUNFEOPELfmvv+4xiNg2sRYeS/P84pTW0TCgP5zc9FpXetHY0ab7SxKyAQCNCc1eK0459uoLI1y5oO5Vc1dbhA==",
+			"dev": true,
+			"requires": {
+				"micromark-util-symbol": "^2.0.0"
+			}
+		},
+		"micromark-util-classify-character": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/micromark-util-classify-character/-/micromark-util-classify-character-2.0.1.tgz",
+			"integrity": "sha512-K0kHzM6afW/MbeWYWLjoHQv1sgg2Q9EccHEDzSkxiP/EaagNzCm7T/WMKZ3rjMbvIpvBiZgwR3dKMygtA4mG1Q==",
+			"dev": true,
+			"requires": {
+				"micromark-util-character": "^2.0.0",
+				"micromark-util-symbol": "^2.0.0",
+				"micromark-util-types": "^2.0.0"
+			}
+		},
+		"micromark-util-combine-extensions": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/micromark-util-combine-extensions/-/micromark-util-combine-extensions-2.0.1.tgz",
+			"integrity": "sha512-OnAnH8Ujmy59JcyZw8JSbK9cGpdVY44NKgSM7E9Eh7DiLS2E9RNQf0dONaGDzEG9yjEl5hcqeIsj4hfRkLH/Bg==",
+			"dev": true,
+			"requires": {
+				"micromark-util-chunked": "^2.0.0",
+				"micromark-util-types": "^2.0.0"
+			}
+		},
+		"micromark-util-decode-numeric-character-reference": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/micromark-util-decode-numeric-character-reference/-/micromark-util-decode-numeric-character-reference-2.0.2.tgz",
+			"integrity": "sha512-ccUbYk6CwVdkmCQMyr64dXz42EfHGkPQlBj5p7YVGzq8I7CtjXZJrubAYezf7Rp+bjPseiROqe7G6foFd+lEuw==",
+			"dev": true,
+			"requires": {
+				"micromark-util-symbol": "^2.0.0"
+			}
+		},
+		"micromark-util-decode-string": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/micromark-util-decode-string/-/micromark-util-decode-string-2.0.1.tgz",
+			"integrity": "sha512-nDV/77Fj6eH1ynwscYTOsbK7rR//Uj0bZXBwJZRfaLEJ1iGBR6kIfNmlNqaqJf649EP0F3NWNdeJi03elllNUQ==",
+			"dev": true,
+			"requires": {
+				"decode-named-character-reference": "^1.0.0",
+				"micromark-util-character": "^2.0.0",
+				"micromark-util-decode-numeric-character-reference": "^2.0.0",
+				"micromark-util-symbol": "^2.0.0"
+			}
+		},
+		"micromark-util-encode": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/micromark-util-encode/-/micromark-util-encode-2.0.1.tgz",
+			"integrity": "sha512-c3cVx2y4KqUnwopcO9b/SCdo2O67LwJJ/UyqGfbigahfegL9myoEFoDYZgkT7f36T0bLrM9hZTAaAyH+PCAXjw==",
+			"dev": true
+		},
+		"micromark-util-html-tag-name": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/micromark-util-html-tag-name/-/micromark-util-html-tag-name-2.0.1.tgz",
+			"integrity": "sha512-2cNEiYDhCWKI+Gs9T0Tiysk136SnR13hhO8yW6BGNyhOC4qYFnwF1nKfD3HFAIXA5c45RrIG1ub11GiXeYd1xA==",
+			"dev": true
+		},
+		"micromark-util-normalize-identifier": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/micromark-util-normalize-identifier/-/micromark-util-normalize-identifier-2.0.1.tgz",
+			"integrity": "sha512-sxPqmo70LyARJs0w2UclACPUUEqltCkJ6PhKdMIDuJ3gSf/Q+/GIe3WKl0Ijb/GyH9lOpUkRAO2wp0GVkLvS9Q==",
+			"dev": true,
+			"requires": {
+				"micromark-util-symbol": "^2.0.0"
+			}
+		},
+		"micromark-util-resolve-all": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/micromark-util-resolve-all/-/micromark-util-resolve-all-2.0.1.tgz",
+			"integrity": "sha512-VdQyxFWFT2/FGJgwQnJYbe1jjQoNTS4RjglmSjTUlpUMa95Htx9NHeYW4rGDJzbjvCsl9eLjMQwGeElsqmzcHg==",
+			"dev": true,
+			"requires": {
+				"micromark-util-types": "^2.0.0"
+			}
+		},
+		"micromark-util-sanitize-uri": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/micromark-util-sanitize-uri/-/micromark-util-sanitize-uri-2.0.1.tgz",
+			"integrity": "sha512-9N9IomZ/YuGGZZmQec1MbgxtlgougxTodVwDzzEouPKo3qFWvymFHWcnDi2vzV1ff6kas9ucW+o3yzJK9YB1AQ==",
+			"dev": true,
+			"requires": {
+				"micromark-util-character": "^2.0.0",
+				"micromark-util-encode": "^2.0.0",
+				"micromark-util-symbol": "^2.0.0"
+			}
+		},
+		"micromark-util-subtokenize": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/micromark-util-subtokenize/-/micromark-util-subtokenize-2.1.0.tgz",
+			"integrity": "sha512-XQLu552iSctvnEcgXw6+Sx75GflAPNED1qx7eBJ+wydBb2KCbRZe+NwvIEEMM83uml1+2WSXpBAcp9IUCgCYWA==",
+			"dev": true,
+			"requires": {
+				"devlop": "^1.0.0",
+				"micromark-util-chunked": "^2.0.0",
+				"micromark-util-symbol": "^2.0.0",
+				"micromark-util-types": "^2.0.0"
+			}
+		},
+		"micromark-util-symbol": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/micromark-util-symbol/-/micromark-util-symbol-2.0.1.tgz",
+			"integrity": "sha512-vs5t8Apaud9N28kgCrRUdEed4UJ+wWNvicHLPxCa9ENlYuAY31M0ETy5y1vA33YoNPDFTghEbnh6efaE8h4x0Q==",
+			"dev": true
+		},
+		"micromark-util-types": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/micromark-util-types/-/micromark-util-types-2.0.2.tgz",
+			"integrity": "sha512-Yw0ECSpJoViF1qTU4DC6NwtC4aWGt1EkzaQB8KPPyCRR8z9TWeV0HbEFGTO+ZY1wB22zmxnJqhPyTpOVCpeHTA==",
 			"dev": true
 		},
 		"minimatch": {
@@ -14196,6 +15380,29 @@
 				"get-proto": "^1.0.1",
 				"gopd": "^1.2.0",
 				"set-function-name": "^2.0.2"
+			}
+		},
+		"remark-parse": {
+			"version": "11.0.0",
+			"resolved": "https://registry.npmjs.org/remark-parse/-/remark-parse-11.0.0.tgz",
+			"integrity": "sha512-FCxlKLNGknS5ba/1lmpYijMUzX2esxW5xQqjWxw2eHFfS2MSdaHVINFmhjo+qN1WhZhNimq0dZATN9pH0IDrpA==",
+			"dev": true,
+			"requires": {
+				"@types/mdast": "^4.0.0",
+				"mdast-util-from-markdown": "^2.0.0",
+				"micromark-util-types": "^2.0.0",
+				"unified": "^11.0.0"
+			}
+		},
+		"remark-stringify": {
+			"version": "11.0.0",
+			"resolved": "https://registry.npmjs.org/remark-stringify/-/remark-stringify-11.0.0.tgz",
+			"integrity": "sha512-1OSmLd3awB/t8qdoEOMazZkNsfVTeY4fTsgzcQFdXNq8ToTN4ZGwrMnlda4K6smTFKD+GRV6O48i6Z4iKgPPpw==",
+			"dev": true,
+			"requires": {
+				"@types/mdast": "^4.0.0",
+				"mdast-util-to-markdown": "^2.0.0",
+				"unified": "^11.0.0"
 			}
 		},
 		"require-directory": {
@@ -14883,6 +16090,12 @@
 				"eslint-visitor-keys": "^3.0.0"
 			}
 		},
+		"trough": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/trough/-/trough-2.2.0.tgz",
+			"integrity": "sha512-tmMpK00BjZiUyVyvrBK7knerNgmgvcV/KLVyuma/SC+TQN167GrMRciANTz09+k3zW8L8t60jWO1GpfkZdjTaw==",
+			"dev": true
+		},
 		"ts-api-utils": {
 			"version": "2.5.0",
 			"resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.5.0.tgz",
@@ -15037,6 +16250,60 @@
 			"integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
 			"dev": true
 		},
+		"unified": {
+			"version": "11.0.5",
+			"resolved": "https://registry.npmjs.org/unified/-/unified-11.0.5.tgz",
+			"integrity": "sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==",
+			"dev": true,
+			"requires": {
+				"@types/unist": "^3.0.0",
+				"bail": "^2.0.0",
+				"devlop": "^1.0.0",
+				"extend": "^3.0.0",
+				"is-plain-obj": "^4.0.0",
+				"trough": "^2.0.0",
+				"vfile": "^6.0.0"
+			}
+		},
+		"unist-util-is": {
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-6.0.1.tgz",
+			"integrity": "sha512-LsiILbtBETkDz8I9p1dQ0uyRUWuaQzd/cuEeS1hoRSyW5E5XGmTzlwY1OrNzzakGowI9Dr/I8HVaw4hTtnxy8g==",
+			"dev": true,
+			"requires": {
+				"@types/unist": "^3.0.0"
+			}
+		},
+		"unist-util-stringify-position": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-4.0.0.tgz",
+			"integrity": "sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ==",
+			"dev": true,
+			"requires": {
+				"@types/unist": "^3.0.0"
+			}
+		},
+		"unist-util-visit": {
+			"version": "5.1.0",
+			"resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-5.1.0.tgz",
+			"integrity": "sha512-m+vIdyeCOpdr/QeQCu2EzxX/ohgS8KbnPDgFni4dQsfSCtpz8UqDyY5GjRru8PDKuYn7Fq19j1CQ+nJSsGKOzg==",
+			"dev": true,
+			"requires": {
+				"@types/unist": "^3.0.0",
+				"unist-util-is": "^6.0.0",
+				"unist-util-visit-parents": "^6.0.0"
+			}
+		},
+		"unist-util-visit-parents": {
+			"version": "6.0.2",
+			"resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-6.0.2.tgz",
+			"integrity": "sha512-goh1s1TBrqSqukSc8wrjwWhL0hiJxgA8m4kFxGlQ+8FYQ3C/m11FcTs4YYem7V664AhHVvgoQLk890Ssdsr2IQ==",
+			"dev": true,
+			"requires": {
+				"@types/unist": "^3.0.0",
+				"unist-util-is": "^6.0.0"
+			}
+		},
 		"uri-js": {
 			"version": "4.4.1",
 			"resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
@@ -15069,6 +16336,26 @@
 			"resolved": "https://registry.npmjs.org/valibot/-/valibot-1.4.2.tgz",
 			"integrity": "sha512-gjdCvJ6d3RyHAneqxMYMW9QMCwYMb3jpOO0IyHZV1bnRHFBHrX3VkIILt5XYR0WhwHiH7Mty8ovuPZ/O3gamrg==",
 			"requires": {}
+		},
+		"vfile": {
+			"version": "6.0.3",
+			"resolved": "https://registry.npmjs.org/vfile/-/vfile-6.0.3.tgz",
+			"integrity": "sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==",
+			"dev": true,
+			"requires": {
+				"@types/unist": "^3.0.0",
+				"vfile-message": "^4.0.0"
+			}
+		},
+		"vfile-message": {
+			"version": "4.0.3",
+			"resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-4.0.3.tgz",
+			"integrity": "sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw==",
+			"dev": true,
+			"requires": {
+				"@types/unist": "^3.0.0",
+				"unist-util-stringify-position": "^4.0.0"
+			}
 		},
 		"vitest": {
 			"version": "4.1.11",
@@ -15511,6 +16798,12 @@
 			"version": "3.25.76",
 			"resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
 			"integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+			"dev": true
+		},
+		"zwitch": {
+			"version": "2.0.4",
+			"resolved": "https://registry.npmjs.org/zwitch/-/zwitch-2.0.4.tgz",
+			"integrity": "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==",
 			"dev": true
 		}
 	}

--- a/package.json
+++ b/package.json
@@ -48,12 +48,13 @@
 		"eslint": "^9.39.2",
 		"eslint-plugin-obsidianmd": "^0.4.1",
 		"globals": "^17.3.0",
+		"i18next": "^26.4.0",
 		"jiti": "^2.7.0",
-		"obsidian": "^1.12.3",
+		"obsidian": "^1.13.1",
 		"obsidian-integration-testing": "^10.3.2",
 		"obsidian-typings": "^6.32.0",
 		"tslib": "2.3.1",
-		"typescript": "^5.9.3",
+		"typescript": "^6.0.3",
 		"vitest": "^4.1.11"
 	},
 	"dependencies": {

--- a/package.json
+++ b/package.json
@@ -53,8 +53,11 @@
 		"obsidian": "^1.13.1",
 		"obsidian-integration-testing": "^10.3.2",
 		"obsidian-typings": "^6.32.0",
+		"remark-parse": "^11.0.0",
+		"remark-stringify": "^11.0.0",
 		"tslib": "2.3.1",
 		"typescript": "^6.0.3",
+		"unified": "^11.0.5",
 		"vitest": "^4.1.11"
 	},
 	"dependencies": {

--- a/scripts/translations_to_json.ts
+++ b/scripts/translations_to_json.ts
@@ -1,0 +1,89 @@
+import { unified } from "unified";
+import remarkParse from "remark-parse";
+import remarkStringify from "remark-stringify";
+import type { Root } from "mdast";
+import fs from "fs"
+
+const parser = unified().use(remarkParse)
+const stringify = unified().use(remarkStringify)
+
+
+const path = "src/i18n/locales/en";
+
+const files = fs.readdirSync(path).filter((file) => file.endsWith(".md"));
+async function main() {
+	for (const file of files) {
+		const filePath = `${path}/${file}`;
+		const data = fs.readFileSync(filePath, "utf-8");
+		const parsedData = await parseData(data)
+		const outputFilePath = `src/i18n/locales/en/${file.replace(".md", ".json")}`;
+		fs.writeFileSync(outputFilePath, parsedData);
+	}
+}
+
+async function parseData(data: string): Promise<string> {
+	const tree = parser.parse(data)
+	return parseNodes(tree, data)
+}
+
+type TranslationValue = string | RecursiveRecord;
+
+interface RecursiveRecord {
+    [key: string]: TranslationValue;
+}
+
+async function parseNodes(tree: Root, source: string) {
+	const result: RecursiveRecord = {}
+	const keys: string[] = ["root"];
+	let start = 0;
+	let previous_heading = true
+	for (const node of tree.children) {
+		if (node.type !== "heading") {
+			previous_heading = false
+			continue
+		} else if (node.position === undefined) {
+			throw new Error("unexpected position")
+		}
+		const pos_start = node.position.start
+		const pos_end = node.position.end
+		const start_offset = pos_start.offset
+		const end_offset = pos_end.offset
+		if (start_offset === undefined || end_offset === undefined) {
+			throw new Error("unexpected offset")
+		}
+		if (!previous_heading) {
+			insert_text(result, keys, source, start, start_offset);
+		}
+		start = end_offset;
+
+
+		const children = node.children
+		const textNode = children[0]
+		if (children.length !== 1 || textNode.type !== "text") {
+			throw new Error("Headings must only contain text")
+		}
+		keys.length = node.depth
+		keys.push(textNode.value)
+		previous_heading = true
+	}
+	insert_text(result, keys, source, start, source.length)
+	return JSON.stringify(result["root"], null, 4).replaceAll(/^((?: {4})+)/gm, (match) => "\t".repeat(match.length/4)) + "\n"
+}
+
+main()
+function insert_text(result: RecursiveRecord, keys: string[], source: string, start: number, start_offset: number) {
+	let obj: RecursiveRecord = result;
+	let key: string = keys[0];
+	for (let i = 0; i < keys.length - 1; i++) {
+		key = keys[i];
+		obj[key] = obj[key] ?? {};
+		const value = obj[key];
+		if (typeof value === "string") {
+			console.log(obj, key);
+			throw "Unexpected string value in object, expected nested object. Headers can only contain other headers or text, not both.";
+		} else {
+			obj = value;
+		}
+	}
+	obj[keys[keys.length - 1]] = source.slice(start, start_offset).trim();
+}

--- a/scripts/translations_to_md.ts
+++ b/scripts/translations_to_md.ts
@@ -1,0 +1,36 @@
+import fs from "fs"
+
+const path = "src/i18n/locales/en";
+
+const files = fs.readdirSync(path).filter((file) => file.endsWith(".json"));
+for (const file of files) {
+	const filePath = `${path}/${file}`;
+	const data = fs.readFileSync(filePath, "utf-8");
+	const jsonData = JSON.parse(data);
+	const parsedData = parseKey(jsonData);
+	const outputFilePath = `src/i18n/locales/en/${file.replace(".json", ".md")}`;
+	fs.writeFileSync(outputFilePath, parsedData);
+}
+
+type TranslationValue = string | RecursiveRecord;
+
+interface RecursiveRecord {
+    [key: string]: TranslationValue;
+}
+
+function parseKey(translation: RecursiveRecord, depth=1): string {
+	const result: string[] = []
+	for (const [key, value] of Object.entries(translation)) {
+		if (typeof value === "object" && value !== null) {
+			result.push(`${"#".repeat(depth)} ${key}`);
+			result.push(parseKey(value, depth + 1));
+		} else if (typeof value === "string") {
+			result.push(
+`${"#".repeat(depth)} ${key}
+${value}
+`
+			)
+		}
+	}
+	return result.join("\n");
+}

--- a/src/i18n/i18n.ts
+++ b/src/i18n/i18n.ts
@@ -1,0 +1,16 @@
+import resources from "./resources";
+import type { i18n } from "i18next";
+export const i18nextOriginal = (window as unknown as { i18next: i18n }).i18next;
+
+export const ns = [
+	"settings",
+]
+
+export const i18next = i18nextOriginal.createInstance({
+	lng: "en",
+	ns,
+	resources,
+})
+// i18next.addResourceBundle("en", "settings", resources.en.settings)
+
+export default i18next

--- a/src/i18n/i18n.ts
+++ b/src/i18n/i18n.ts
@@ -1,16 +1,23 @@
-import resources from "./resources";
-import type { i18n } from "i18next";
-export const i18nextOriginal = (window as unknown as { i18next: i18n }).i18next;
+import type { i18n, Namespace, TFunction } from "i18next";
+export const i18next = (window as unknown as { i18next: i18n }).i18next;
 
-export const ns = [
-	"settings",
-]
 
-export const i18next = i18nextOriginal.createInstance({
-	lng: "en",
-	ns,
-	resources,
-})
-// i18next.addResourceBundle("en", "settings", resources.en.settings)
 
 export default i18next
+
+
+// obsidian ships with older version where keyPrefix isn't supported
+export function getFixedT<
+	Prefix extends string,
+	Ns extends Namespace,
+>(ns: Ns, prefix: Prefix): TFunction<Ns, Prefix> {
+  const translateFn = (key: string) => {
+    const fullKey = (key ? `${String(ns)}:${prefix}.${key}` : `${String(ns)}:${prefix}`);
+    return (i18next.t as (key: string) => string)(fullKey);
+  };
+
+  return translateFn as unknown as TFunction<Ns, Prefix>;
+}
+
+
+export const settings_translation = getFixedT("obsidian-latex-suite", "settings");

--- a/src/i18n/i18next.d.ts
+++ b/src/i18n/i18next.d.ts
@@ -2,7 +2,9 @@ import resources from "./resources";
 
 declare module "i18next" {
   interface CustomTypeOptions {
-    resources: typeof resources["en"];
-	defaultNS: "settings"
+    resources: {
+		"obsidian-latex-suite": typeof resources["en"];
+	};
+	defaultNS: "obsidian-latex-suite";
   }
 }

--- a/src/i18n/i18next.d.ts
+++ b/src/i18n/i18next.d.ts
@@ -1,0 +1,8 @@
+import resources from "./resources";
+
+declare module "i18next" {
+  interface CustomTypeOptions {
+    resources: typeof resources["en"];
+	defaultNS: "settings"
+  }
+}

--- a/src/i18n/locales/README.md
+++ b/src/i18n/locales/README.md
@@ -1,0 +1,17 @@
+# Instructions
+
+- Fork the repo, and clone your fork locally.
+- Update per below
+- Submit a pull request
+
+# UI strings translations
+
+- Copy `src/i18n/locales/en` to ``src/i18n/locales/<insert-your-language-code>`
+- Then translate the string either:
+	- translate the json files directly, where every `desc` key is markdown and the rest is raw text.
+	  It might be helpful to turn on word wrap in your editor because the json strings have to be in one line.
+	- Or if you're more comfortable with markdown
+		- run `npm install` to install the dependencies for the scripts
+		- run `npx jiti scripts/translations_to_md.ts` to convert all json files to markdown
+		- Translate the text after the headers. Whitespace at the beginning and end is ignored and only `desc` headers are rendered as markdown.
+		- run `npx jiti scripts/translations_to_json.ts` to convert the markdown files back into json files.

--- a/src/i18n/locales/en/settings.json
+++ b/src/i18n/locales/en/settings.json
@@ -1,0 +1,226 @@
+{
+	"snippets": {
+		"heading": "Snippets",
+		"enabled": {
+			"name": "Enabled",
+			"desc": "Whether snippets are enabled."
+		},
+		"snippets": {
+			"name": "Snippets",
+			"desc": "Enter snippets here. Remember to add a comma after each snippet, and escape all backslashes with an extra \\. Lines starting with \"\\\\\" will be treated as comments and ignored."
+		},
+		"load-from-file": {
+			"name": "Load snippets from file or folder",
+			"desc": "Whether to load snippets from specified file, or from all files within a folder (instead of from the plugin settings)."
+		},
+		"file-path": {
+			"name": "Snippets file or folder location",
+			"desc": "<div>The file or folder to load snippets from. On desktop you can use ~/ or an absolute path. Files outside your vault or in hidden folders may not be watched for changes depending on you OS.</div>"
+		}
+	},
+	"conceal": {
+		"heading": "Conceal",
+		"enabled": {
+			"name": "Enabled",
+			"desc": "<div>Make equations more readable by hiding LaTeX syntax and instead displaying it in a pretty format.</div><div>e.g.<code>\\dot{x}^{2} + \\dot{y}^{2}</code> will display as <code>ẋ² + ẏ²</code> and <code>\\sqrt{ 1-\\beta^{2} }</code> will display as <code>√(1-β²)</code></div><div>LaTeX beneath the cursor will be revealed.</div><br><div>Disabled by default to not confuse new users. However, I recommend turning this on once you are comfortable with the plugin!.</div>"
+		},
+		"reveal-delay": {
+			"name": "Reveal delay (ms)",
+			"desc": "<div>How long to delay the reveal of LaTeX for, in milliseconds, when the cursor moves over LaTeX. Defaults to 0 (LaTeX under the cursor is revealed immediately).</div><br><div>Can be set to a positive number, e.g. 300, to delay the reveal of LaTeX, making it much easier to navigate equations using arrow keys.</div><br><div>Must be an integer ≥ 0.</div>"
+		}
+	},
+	"highlight-brackets": {
+		"heading": "Highlight and color brackets",
+		"color-brackets": {
+			"name": "Color paired brackets",
+			"desc": "Whether to colorize matching brackets."
+		},
+		"highlight-brackets": {
+			"name": "Highlight matching bracket beneath cursor",
+			"desc": "When the cursor is adjacent to a bracket, highlight the matching bracket."
+		},
+		"color-math": {
+			"name": "Color math delimiters",
+			"desc": "Whether to colorize matched and mismatched math delimiters in the editor according to latex suite parser. This parser behaves closer to the reading view parser than the editor/syntax highlighting parser."
+		}
+	},
+	"math-preview": {
+		"heading": "Math popup preview",
+		"enabled": {
+			"name": "Enabled",
+			"desc": "<div>When inside an equation, show a popup preview window of the rendered math.</div><br><div>The popup preview will be shown for all inline math equations, as well as for block math equations in Source mode.</div>"
+		},
+		"position": {
+			"name": "Position",
+			"desc": "Where to display the popup preview relative to the equation source.",
+			"options": {
+				"above": "Above",
+				"below": "Below"
+			}
+		},
+		"cursor-symbol": {
+			"name": "Cursor symbol",
+			"desc": "The symbol to use as the cursor in the popup preview such as {{cursor}}. Leave it blank to turn it off."
+		},
+		"highlight-brackets": {
+			"name": "Highlight brackets in preview",
+			"desc": "Whether to highlight the area within the nearest pair of brackets around the cursor in the popup preview."
+		},
+		"display-live-preview": {
+			"name": "Display live preview",
+			"desc": "Whether to display the tooltip in live preview mode. The cursor and bracket highlighting will only be shown in this preview and not in obsidian's preview"
+		}
+	},
+	"auto-fraction": {
+		"heading": "Auto-fraction",
+		"enabled": {
+			"name": "Enabled",
+			"desc": "Whether auto-fraction is enabled."
+		},
+		"fraction-symbol": {
+			"name": "Fraction symbol",
+			"desc": "<div>The fraction symbol to use in the replacement. e.g. <code>\\frac</code>, <code>\\dfrac</code>, <code>\\tfrac</code>.</div>"
+		},
+		"excluded-environments": {
+			"name": "Excluded environments",
+			"desc": "A list of environments to exclude auto-fraction from running in. For example, to exclude auto-fraction from running while inside an exponent, such as `e^{...}`, use [\"^{\", \"}\"]"
+		},
+		"breaking-characters": {
+			"name": "Breaking characters",
+			"desc": "A list of characters that denote the start/end of a fraction. e.g. if `+` is included in the list, `a+b/c` will expand to `a+\\frac{b}{c}`. If `+` is not in the list, it will expand to `\\frac{a+b}{c}`."
+		}
+	},
+	"matrix-shortcuts": {
+		"heading": "Matrix shortcuts",
+		"enabled": {
+			"name": "Enabled",
+			"desc": "Whether matrix shortcuts are enabled."
+		},
+		"environments": {
+			"name": "Environments",
+			"desc": "A list of environment names to run the matrix shortcuts in, separated by commas."
+		},
+		"macros": {
+			"name": "Macros",
+			"desc": "A list of macros names to run the matrix shortcuts in, separated by commas."
+		}
+	},
+	"tabout": {
+		"heading": "Tabout",
+		"enabled": {
+			"name": "Enabled",
+			"desc": "Whether tabout is enabled."
+		},
+		"closing-brackets": {
+			"name": "Closing brackets",
+			"desc": "A list of closing brackets for tabout, separated by commas."
+		},
+		"exit-EOL": {
+			"name": "Exit equation only on EOL",
+			"desc": "Whether to exit the equation only when the cursor is at the end of line"
+		}
+	},
+	"auto-enlarge": {
+		"heading": "Auto-enlarge brackets",
+		"enabled": {
+			"name": "Enabled",
+			"desc": "Whether to automatically enlarge brackets containing e.g. sum, int, frac."
+		},
+		"triggers": {
+			"name": "Triggers",
+			"desc": "A list of symbols that should trigger auto-enlarge brackets, separated by commas."
+		},
+		"space": {
+			"name": "Space",
+			"desc": "Whether to add a space after \\left( and before \\right) or not"
+		}
+	},
+	"advanced-snippets": {
+		"heading": "Advanced snippets",
+		"variables": {
+			"name": "Snippet variables",
+			"desc": "Assign snippet variables that can be used as shortcuts when writing snippets"
+		},
+		"load-variables-from-file": {
+			"name": "Load snippet variables from file or folder",
+			"desc": "Whether to load snippet variables from a specified file, or from all files within a folder (instead of from the plugin settings)."
+		},
+		"variables-file-path": {
+			"name": "Snippet variables file or folder location",
+			"desc": "<div>The file or folder to load snippet variables from. On desktop you can use ~/ or an absolute path. Files outside your vault or in hidden folders may not be watched for changes depending on your os.</div>"
+		},
+		"word-delimiters": {
+			"name": "Word delimiters",
+			"desc": "Symbols that will be treated as word delimiters, for use with the \"w\" snippet option"
+		},
+		"trailing-whitespace": {
+			"name": "Remove trailing whitespace in snippets in inline math",
+			"desc": "Whether to remove trailing whitespaces when expanding snippets at the end of inline math blocks."
+		},
+		"auto-delete$": {
+			"name": "Remove closing $ when backspacing inside blank inline math",
+			"desc": "Whether to also remove closing $ when you delete the opening $ symbol inside blank inline math."
+		},
+		"suppress-IME": {
+			"name": "Don't trigger snippets when IME is active",
+			"desc": "Whether to suppress snippets triggering when an IME is active."
+		},
+		"suppress-IME-warning": {
+			"name": "Suppress IME warning",
+			"desc": "Whether a warning is shown on startup if `Don't trigger snippets when IME is active` is enabled. Disable that setting if you are aware of the IME limitations. Currently only ios and android touch/swipe keyboards like gboard have support for IME. See https://github.com/artisticat1/obsidian-latex-suite/blob/main/DOCS.md#IME-keyboards for more info."
+		},
+		"code-languages": {
+			"name": "Code languages to interpret as math mode",
+			"desc": "Codeblock languages where the whole code block should be treated like a math block separated by commas."
+		},
+		"snippet-debug-mode": {
+			"name": "Snippet debug mode",
+			"desc": "Set the level of debug information to log about snippet expansion. Set to \"info\" or \"verbose\" to help identify which and what snippet is expanding. Verbose mode will log most information to the developer console on debug level.",
+			"options": {
+				"off": "Off",
+				"info": "Info",
+				"verbose": "Verbose"
+			}
+		}
+	},
+	"vim": {
+		"enabled": {
+			"name": "Vim key bindings",
+			"desc": "turn on/off vim keybindings. Note vim needs to be enabled in obsidian itself."
+		},
+		"select-mode": {
+			"name": "Vim: Switch from visual mode to select mode",
+			"desc": "maps the key to switch from visual mode to select mode.Keymap must be vim keymap and can't contain any spaces. Use empty string to disable this feature. (select mode=insert keybindings)"
+		},
+		"visual-mode": {
+			"name": "Vim: Switch from select mode to visual mode",
+			"desc": "maps the key to switch from select mode to visual mode. must be a vim keymap and can't contain any spaces. Example <C-g><C-A-i> = Ctrl-g + Ctrl-Alt-i. Please check the vim keybinding first on another command like w before reporting it. Some keybindings like shift don't work due to the original vim plugin. Use empty string to disable this feature. (select mode=insert keybindings)"
+		},
+		"matrix-enter": {
+			"name": "Vim: run matrix enter",
+			"desc": "maps the key to the action of inserting a new line below while appending \\\\ to the current line in a matrix environment. Use empty string to disable this feature."
+		}
+	},
+	"keymap": {
+		"desc": "<div>What key to press to trigger the action. Should follow codemirror 6 keymap syntax such as <code>Ctrl-k Ctrl-a</code> For more info see <a href=\"https://codemirror.net/6/docs/ref/#keymap\">codemirror keymap</a></div><br><div>Note that some keymaps may not work due to conflicts with obsidian or other plugins.</div><br><div>The actions are expanded in the order that they are listed. Custom keymaps in snippets are on the same priority as <code>$t(settings:keymap.snippet)</code>.",
+		"heading": {
+			"name": "Keymap",
+			"desc": "codemirror 6 keymaps for snippets and tabout."
+		},
+		"snippet": "expand manual snippets",
+		"next-tabstop": "next tabstop",
+		"prev-tabstop": "previous tabstop",
+		"tabout": "tabout"
+		
+	},
+	"experimental": {
+		"heading": {
+			"name": "Experimental features",
+			"desc": "Features that are still in testing and may need user feedback. Backwards compatibility may break for these features or these settings may be overridden."
+		},
+		"snippet-recursion": {
+			"name": "Snippet recursion",
+			"desc": "<div>How many times to run snippets in a row. Set to 0 to disable recursion.</div>\n\n[Related pr/feedback](https://github.com/artisticat1/obsidian-latex-suite/pull/536)"
+		}
+	}
+}

--- a/src/i18n/locales/en/settings.json
+++ b/src/i18n/locales/en/settings.json
@@ -3,11 +3,11 @@
 		"heading": "Snippets",
 		"enabled": {
 			"name": "Enabled",
-			"desc": "Whether snippets are enabled."
+			"desc": "Whether snippets are enabled. For more info on how to format snippets see the [documentation](https://github.com/artisticat1/obsidian-latex-suite/blob/main/DOCS.md#snippets)."
 		},
 		"snippets": {
 			"name": "Snippets",
-			"desc": "Enter snippets here. Remember to add a comma after each snippet, and escape all backslashes with an extra \\. Lines starting with \"\\\\\" will be treated as comments and ignored."
+			"desc": "Enter snippets here. Remember to add a comma after each snippet, and escape all backslashes with an extra `\\`. Lines starting with `//` will be treated as comments and ignored."
 		},
 		"load-from-file": {
 			"name": "Load snippets from file or folder",
@@ -15,18 +15,18 @@
 		},
 		"file-path": {
 			"name": "Snippets file or folder location",
-			"desc": "<div>The file or folder to load snippets from. On desktop you can use ~/ or an absolute path. Files outside your vault or in hidden folders may not be watched for changes depending on you OS.</div>"
+			"desc": "The file or folder to load snippets from. On desktop you can use ~/ or an absolute path. Files outside your vault or in hidden folders may not be watched for changes depending on your OS."
 		}
 	},
 	"conceal": {
 		"heading": "Conceal",
 		"enabled": {
 			"name": "Enabled",
-			"desc": "<div>Make equations more readable by hiding LaTeX syntax and instead displaying it in a pretty format.</div><div>e.g.<code>\\dot{x}^{2} + \\dot{y}^{2}</code> will display as <code>ẋ² + ẏ²</code> and <code>\\sqrt{ 1-\\beta^{2} }</code> will display as <code>√(1-β²)</code></div><div>LaTeX beneath the cursor will be revealed.</div><br><div>Disabled by default to not confuse new users. However, I recommend turning this on once you are comfortable with the plugin!.</div>"
+			"desc": "Make equations more readable by hiding LaTeX syntax and instead displaying it in a pretty format.\ne.g.`\\dot{x}^{2} + \\dot{y}^{2}` will display as `ẋ² + ẏ²` and `\\sqrt{ 1-\\beta^{2} }` will display as `√(1-β²)`\nLaTeX beneath the cursor will be revealed.\n\nDisabled by default to not confuse new users. However, I recommend turning this on once you are comfortable with the plugin!."
 		},
 		"reveal-delay": {
 			"name": "Reveal delay (ms)",
-			"desc": "<div>How long to delay the reveal of LaTeX for, in milliseconds, when the cursor moves over LaTeX. Defaults to 0 (LaTeX under the cursor is revealed immediately).</div><br><div>Can be set to a positive number, e.g. 300, to delay the reveal of LaTeX, making it much easier to navigate equations using arrow keys.</div><br><div>Must be an integer ≥ 0.</div>"
+			"desc": "How long to delay the reveal of LaTeX for, in milliseconds, when the cursor moves over LaTeX. Defaults to 0 (LaTeX under the cursor is revealed immediately).\n\nCan be set to a positive number, e.g. 300, to delay the reveal of LaTeX, making it much easier to navigate equations using arrow keys.\n\nMust be an integer ≥ 0."
 		}
 	},
 	"highlight-brackets": {
@@ -48,7 +48,7 @@
 		"heading": "Math popup preview",
 		"enabled": {
 			"name": "Enabled",
-			"desc": "<div>When inside an equation, show a popup preview window of the rendered math.</div><br><div>The popup preview will be shown for all inline math equations, as well as for block math equations in Source mode.</div>"
+			"desc": "When inside an equation, show a popup preview window of the rendered math.\n\nThe popup preview will be shown for all inline math equations, as well as for block math equations in Source mode."
 		},
 		"position": {
 			"name": "Position",
@@ -79,11 +79,11 @@
 		},
 		"fraction-symbol": {
 			"name": "Fraction symbol",
-			"desc": "<div>The fraction symbol to use in the replacement. e.g. <code>\\frac</code>, <code>\\dfrac</code>, <code>\\tfrac</code>.</div>"
+			"desc": "The fraction symbol to use in the replacement. e.g. `\\frac`, `\\dfrac`, `\\tfrac`."
 		},
 		"excluded-environments": {
 			"name": "Excluded environments",
-			"desc": "A list of environments to exclude auto-fraction from running in. For example, to exclude auto-fraction from running while inside an exponent, such as `e^{...}`, use [\"^{\", \"}\"]"
+			"desc": "A list of environments to exclude auto-fraction from running in. For example, to exclude auto-fraction from running while inside an exponent, such as `e^{...}`, use `[\"^{\", \"}\"]`"
 		},
 		"breaking-characters": {
 			"name": "Breaking characters",
@@ -132,7 +132,7 @@
 		},
 		"space": {
 			"name": "Space",
-			"desc": "Whether to add a space after \\left( and before \\right) or not"
+			"desc": "Whether to add a space after `\\left(` and before `\\right)` or not"
 		}
 	},
 	"advanced-snippets": {
@@ -147,11 +147,11 @@
 		},
 		"variables-file-path": {
 			"name": "Snippet variables file or folder location",
-			"desc": "<div>The file or folder to load snippet variables from. On desktop you can use ~/ or an absolute path. Files outside your vault or in hidden folders may not be watched for changes depending on your os.</div>"
+			"desc": "The file or folder to load snippet variables from. On desktop you can use ~/ or an absolute path. Files outside your vault or in hidden folders may not be watched for changes depending on your os."
 		},
 		"word-delimiters": {
 			"name": "Word delimiters",
-			"desc": "Symbols that will be treated as word delimiters, for use with the \"w\" snippet option"
+			"desc": "Symbols that will be treated as word delimiters, for use with the `w` snippet option"
 		},
 		"trailing-whitespace": {
 			"name": "Remove trailing whitespace in snippets in inline math",
@@ -167,7 +167,7 @@
 		},
 		"suppress-IME-warning": {
 			"name": "Suppress IME warning",
-			"desc": "Whether a warning is shown on startup if `Don't trigger snippets when IME is active` is enabled. Disable that setting if you are aware of the IME limitations. Currently only ios and android touch/swipe keyboards like gboard have support for IME. See https://github.com/artisticat1/obsidian-latex-suite/blob/main/DOCS.md#IME-keyboards for more info."
+			"desc": "Whether a warning is shown on startup if `$t(settings:advanced-snippets.suppress-IME.name)` is enabled. Disable that setting if you are aware of the IME limitations. Currently only ios and android touch/swipe keyboards like gboard have support for IME. See [here](https://github.com/artisticat1/obsidian-latex-suite/blob/main/DOCS.md#IME-keyboards) for more info."
 		},
 		"code-languages": {
 			"name": "Code languages to interpret as math mode",
@@ -175,7 +175,7 @@
 		},
 		"snippet-debug-mode": {
 			"name": "Snippet debug mode",
-			"desc": "Set the level of debug information to log about snippet expansion. Set to \"info\" or \"verbose\" to help identify which and what snippet is expanding. Verbose mode will log most information to the developer console on debug level.",
+			"desc": "Set the level of debug information to log about snippet expansion. Set to `info` or `verbose` to help identify which and what snippet is expanding. Verbose mode will log most information to the developer console on debug level.",
 			"options": {
 				"off": "Off",
 				"info": "Info",
@@ -186,23 +186,23 @@
 	"vim": {
 		"enabled": {
 			"name": "Vim key bindings",
-			"desc": "turn on/off vim keybindings. Note vim needs to be enabled in obsidian itself."
+			"desc": "Turn on/off vim keybindings. Note vim needs to be enabled in obsidian itself."
 		},
 		"select-mode": {
 			"name": "Vim: Switch from visual mode to select mode",
-			"desc": "maps the key to switch from visual mode to select mode.Keymap must be vim keymap and can't contain any spaces. Use empty string to disable this feature. (select mode=insert keybindings)"
+			"desc": "Maps the key to switch from visual mode to select mode.Keymap must be vim keymap and can't contain any spaces. Use empty string to disable this feature. (select mode=insert keybindings)"
 		},
 		"visual-mode": {
 			"name": "Vim: Switch from select mode to visual mode",
-			"desc": "maps the key to switch from select mode to visual mode. must be a vim keymap and can't contain any spaces. Example <C-g><C-A-i> = Ctrl-g + Ctrl-Alt-i. Please check the vim keybinding first on another command like w before reporting it. Some keybindings like shift don't work due to the original vim plugin. Use empty string to disable this feature. (select mode=insert keybindings)"
+			"desc": "Maps the key to switch from select mode to visual mode. must be a vim keymap and can't contain any spaces. Example `<C-g><C-A-i>` = `Ctrl-g + Ctrl-Alt-i`. Please check the vim keybinding first on another command like w before reporting it. Some keybindings like shift don't work due to the original vim plugin. Use empty string to disable this feature. (select mode=insert keybindings)"
 		},
 		"matrix-enter": {
 			"name": "Vim: run matrix enter",
-			"desc": "maps the key to the action of inserting a new line below while appending \\\\ to the current line in a matrix environment. Use empty string to disable this feature."
+			"desc": "Maps the key to the action of inserting a new line below while appending `\\\\` to the current line in a matrix environment. Use empty string to disable this feature."
 		}
 	},
 	"keymap": {
-		"desc": "<div>What key to press to trigger the action. Should follow codemirror 6 keymap syntax such as <code>Ctrl-k Ctrl-a</code> For more info see <a href=\"https://codemirror.net/6/docs/ref/#keymap\">codemirror keymap</a></div><br><div>Note that some keymaps may not work due to conflicts with obsidian or other plugins.</div><br><div>The actions are expanded in the order that they are listed. Custom keymaps in snippets are on the same priority as <code>$t(settings:keymap.snippet)</code>.",
+		"desc": "What key to press to trigger the action. Should follow codemirror 6 keymap syntax such as `Ctrl-k Ctrl-a` For more info see [codemirror keymap](https://codemirror.net/6/docs/ref/#keymap)\n\nNote that some keymaps may not work due to conflicts with obsidian or other plugins.\n\nThe actions are expanded in the order that they are listed. Custom keymaps in snippets are on the same priority as `$t(settings:keymap.snippet)`.",
 		"heading": {
 			"name": "Keymap",
 			"desc": "codemirror 6 keymaps for snippets and tabout."
@@ -211,7 +211,6 @@
 		"next-tabstop": "next tabstop",
 		"prev-tabstop": "previous tabstop",
 		"tabout": "tabout"
-		
 	},
 	"experimental": {
 		"heading": {
@@ -220,7 +219,7 @@
 		},
 		"snippet-recursion": {
 			"name": "Snippet recursion",
-			"desc": "<div>How many times to run snippets in a row. Set to 0 to disable recursion.</div>\n\n[Related pr/feedback](https://github.com/artisticat1/obsidian-latex-suite/pull/536)"
+			"desc": "How many times to run snippets in a row. Set to 0 to disable recursion.\n\n[Related pr/feedback](https://github.com/artisticat1/obsidian-latex-suite/pull/536)"
 		}
 	}
 }

--- a/src/i18n/resources.ts
+++ b/src/i18n/resources.ts
@@ -1,0 +1,9 @@
+import settings from "./locales/en/settings.json";
+
+const resources = {
+	en: {
+		settings,
+	}
+} as const;
+
+export default resources;

--- a/src/i18n/resources.ts
+++ b/src/i18n/resources.ts
@@ -1,9 +1,9 @@
-import settings from "./locales/en/settings.json";
+import en_settings from "./locales/en/settings.json";
 
 const resources = {
 	en: {
-		settings,
-	}
+		settings: en_settings,
+	},
 } as const;
 
 export default resources;

--- a/src/main.ts
+++ b/src/main.ts
@@ -20,6 +20,8 @@ import * as v from "valibot"
 import { languageExtension } from "./parser/language";
 import { highlight_dollar } from "./editor_extensions/highlight_dollar";
 import { EMPTY_SETTINGS } from "./settings/empty_settings";
+import i18next from "./i18n/i18n";
+import resources from "./i18n/resources";
 
 export default class LatexSuitePlugin extends Plugin implements LatexSuitePluginPublicApi {
 	settings: LatexSuitePluginSettings = EMPTY_SETTINGS;
@@ -35,6 +37,12 @@ export default class LatexSuitePlugin extends Plugin implements LatexSuitePlugin
 	};
 
 	async onload() {
+		await i18next.init({
+			defaultNS: "settings",
+			ns: ["settings"],
+			lng: "en",
+			resources,
+		})
 		await this.loadSettings();
 
 		this.loadIcons();

--- a/src/main.ts
+++ b/src/main.ts
@@ -37,12 +37,7 @@ export default class LatexSuitePlugin extends Plugin implements LatexSuitePlugin
 	};
 
 	async onload() {
-		await i18next.init({
-			defaultNS: "settings",
-			ns: ["settings"],
-			lng: "en",
-			resources,
-		})
+		i18next.addResourceBundle("en", "obsidian-latex-suite", resources.en)
 		await this.loadSettings();
 
 		this.loadIcons();

--- a/src/settings/settings.ts
+++ b/src/settings/settings.ts
@@ -137,7 +137,7 @@ export const DEFAULT_SETTINGS: LatexSuitePluginSettings = {
 	highlightDollarEnabled: true,
 }
 
-const EnvironmentSchema = v.pipe(
+export const EnvironmentSchema = v.pipe(
 	v.string(),
 	v.parseJson(),
 	v.array(v.looseTuple([v.string(), v.string()], "Every item needs to be an array with 2 items"), "Needs to be an array [item1,item2]"),

--- a/src/settings/settings_tab.ts
+++ b/src/settings/settings_tab.ts
@@ -1,6 +1,6 @@
 import { EditorState, Extension } from "@codemirror/state";
 import { EditorView, ViewUpdate } from "@codemirror/view";
-import { App, ButtonComponent, ExtraButtonComponent, Modal, Notice, Platform, PluginSettingTab, Setting, debounce, setIcon } from "obsidian";
+import { App, ButtonComponent, ExtraButtonComponent, Modal, Notice, Platform, PluginSettingTab, Setting, SettingDefinitionItem, debounce, setIcon } from "obsidian";
 import { parseKeyName, parseSnippetVariables, parseSnippets } from "src/snippets/parse";
 import { DEFAULT_SNIPPETS } from "src/utils/default_snippets";
 import LatexSuitePlugin from "../main";
@@ -8,6 +8,8 @@ import { DEFAULT_SETTINGS, LatexSuiteCMKeymapSettings } from "./settings";
 import { FileSuggest } from "./ui/file_suggest";
 import { basicSetup } from "./ui/snippets_editor/extensions";
 import { getVimSelectModeCommand, vimCommand, getVimVisualModeCommand, getVimEditorCommands, getVimRunMatrixEnterCommand } from "src/features/editor_commands";
+import { LatexSuiteSettingsTab2, renderMarkdown } from "./settings_tab2";
+import {i18next} from "../i18n/i18n";
 
 
 export class LatexSuiteSettingTab extends PluginSettingTab {
@@ -25,6 +27,10 @@ export class LatexSuiteSettingTab extends PluginSettingTab {
 		this.snippetsEditor?.destroy();
 	}
 
+	getSettingDefinitions(): SettingDefinitionItem[] {
+		return new LatexSuiteSettingsTab2(this.app, this.plugin).getSettingDefinitions();
+	}
+
 	addHeading(containerEl: HTMLElement, name: string, icon = "math") {
 		const heading = new Setting(containerEl).setName(name).setHeading();
 
@@ -36,6 +42,7 @@ export class LatexSuiteSettingTab extends PluginSettingTab {
 		parentEl.prepend(iconEl);
 		return heading;
 	}
+
 
 	display(): void {
 		const { containerEl } = this;
@@ -135,19 +142,7 @@ export class LatexSuiteSettingTab extends PluginSettingTab {
 		const containerEl = this.containerEl;
 		this.addHeading(containerEl, "Conceal", "math-integral-x");
 
-		const fragment = new DocumentFragment();
-		fragment.createDiv({}, div => div.setText("Make equations more readable by hiding LaTeX syntax and instead displaying it in a pretty format."));
-		fragment.createDiv({}, (div) => {
-			div.appendText("e.g. ")
-			div.createEl("code", { text: "\\dot{x}^{2} + \\dot{y}^{2}" });
-			div.appendText(" will display as ẋ² + ẏ², and ");
-			div.createEl("code", { text: "\\sqrt{ 1-\\beta^{2} }" });
-			div.appendText(" will display as √{ 1-β² }.");
-		});
-		fragment.createDiv({}, div => div.setText("LaTeX beneath the cursor will be revealed."));
-		fragment.createEl("br");
-		fragment.createDiv({}, div => div.setText("Disabled by default to not confuse new users. However, I recommend turning this on once you are comfortable with the plugin!"));
-
+		const fragment = renderMarkdown(this.app, i18next.t("conceal.enabled.desc"))
 		new Setting(containerEl)
 			.setName("Enabled")
 			.setDesc(fragment)
@@ -159,13 +154,7 @@ export class LatexSuiteSettingTab extends PluginSettingTab {
 				})
 			);
 
-		const fragment2 = new DocumentFragment();
-		fragment2.createDiv({}, div => div.setText("How long to delay the reveal of LaTeX for, in milliseconds, when the cursor moves over LaTeX. Defaults to 0 (LaTeX under the cursor is revealed immediately)."));
-		fragment2.createEl("br");
-		fragment2.createDiv({}, div => div.setText("Can be set to a positive number, e.g. 300, to delay the reveal of LaTeX, making it much easier to navigate equations using arrow keys."));
-		fragment2.createEl("br");
-		fragment2.createDiv({}, div => div.setText("Must be an integer ≥ 0."));
-
+		const fragment2 = renderMarkdown(this.app, i18next.t("conceal.reveal-delay.desc"))
 		new Setting(containerEl)
 			.setName("Reveal delay (ms)")
 			.setDesc(fragment2)
@@ -263,7 +252,7 @@ export class LatexSuiteSettingTab extends PluginSettingTab {
 				text.inputEl.setAttribute("list", "math-preview-cursor-list");
 				return text;
 			});
-		
+
 		const highlightSetting = new Setting(containerEl)
 			.setName("Highlight brackets in preview")
 			.setDesc("Whether to highlight the area within the nearest pair of brackets around the cursor in the popup preview.")
@@ -273,7 +262,7 @@ export class LatexSuiteSettingTab extends PluginSettingTab {
 					this.plugin.settings.mathPreviewBracketHighlighting = value;
 					await this.plugin.saveSettings();
 				}));
-		
+
 		const livePreviewDisplay = new Setting(containerEl)
 			.setName("Display live preview")
 			.setDesc(
@@ -288,7 +277,7 @@ export class LatexSuiteSettingTab extends PluginSettingTab {
 						value;
 					await this.plugin.saveSettings();
 				}));
-			
+
 		const mathPreviewDependentSettings = [positionSetting, cursorSetting, highlightSetting, livePreviewDisplay];
 		mathPreviewDependentSettings.forEach((setting) =>
 			setting.settingEl.toggleClass(
@@ -297,7 +286,7 @@ export class LatexSuiteSettingTab extends PluginSettingTab {
 			),
 		);
 
-		mathPreviewSetting.addToggle(toggle => 
+		mathPreviewSetting.addToggle(toggle =>
 			toggle
 				.setValue(this.plugin.settings.mathPreviewEnabled)
 				.onChange(async (value) => {
@@ -426,7 +415,7 @@ export class LatexSuiteSettingTab extends PluginSettingTab {
 					await this.plugin.saveSettings();
 				}));
 		const taboutTriggerSetting = this.createTriggerSetting(containerEl, "tabout", "taboutTrigger")
-			
+
 		const taboutClosingBracketsSetting =  new Setting(containerEl)
 			.setName("Closing brackets")
 			.setDesc("A list of closing brackets for tabout, separated by commas.")
@@ -480,7 +469,7 @@ export class LatexSuiteSettingTab extends PluginSettingTab {
 
 					await this.plugin.saveSettings();
 				}));
-		
+
 		new Setting(containerEl)
 			.setName("Space")
 			.setDesc("Whether to add a space after \\left( and before \\right) or not")
@@ -623,7 +612,7 @@ export class LatexSuiteSettingTab extends PluginSettingTab {
 
 					await this.plugin.saveSettings();
 				}));
-		
+
 		new Setting(containerEl)
 			.setName("Snippet debug mode")
 			.setDesc("Set the level of debug information to log about snippet expansion. Set to \"info\" or \"verbose\" to help identify issues with snippet syntax or why a snippet is not expanding. Verbose mode will log most information to the developer console on debug level.")
@@ -654,7 +643,7 @@ export class LatexSuiteSettingTab extends PluginSettingTab {
 				.onChange(async (value) => {
 					const oldValue: string = this.plugin.settings.vimSelectMode;
 				this.plugin.settings.vimSelectMode = value;
-				await this.plugin.saveSettings();	
+				await this.plugin.saveSettings();
 				const vimObject = window?.CodeMirrorAdapter?.Vim;
 				if (!vimObject) return;
 				const command: vimCommand = getVimSelectModeCommand(this.plugin.settings);
@@ -667,7 +656,7 @@ export class LatexSuiteSettingTab extends PluginSettingTab {
 		vimSettings.push(selectMode);
 		const visualMode = new Setting(containerEl)
 			.setName("Vim: Switch from select mode to visual mode")
-			.setDesc(`maps the key to switch from select mode to visual mode. 
+			.setDesc(`maps the key to switch from select mode to visual mode.
 				 must be a vim keymap and can't contain any spaces. Example <C-g><C-A-i> = Ctrl-g + Ctrl-Alt-i.
 				 Please check the vim keybinding first on another command like w before reporting it. Some keybindings like shift don't work due to the original vim plugin. Use empty string to disable this feature.
 				  (select mode=insert keybindings)`)
@@ -677,7 +666,7 @@ export class LatexSuiteSettingTab extends PluginSettingTab {
 				.onChange(async (value) => {
 					const oldvalue: string = this.plugin.settings.vimVisualMode;
 					this.plugin.settings.vimVisualMode = value;
-					await this.plugin.saveSettings();	
+					await this.plugin.saveSettings();
 					const command: vimCommand = getVimVisualModeCommand(this.plugin.settings);
 					const vimObject = window?.CodeMirrorAdapter?.Vim;
 					if (!vimObject) return;
@@ -727,7 +716,7 @@ export class LatexSuiteSettingTab extends PluginSettingTab {
 				});
 		});
 	}
-	
+
 	private displayExperimentalSettings() {
 		const containerEl = this.containerEl;
 		this.addHeading(containerEl, "Experimental features", "experiment")

--- a/src/settings/settings_tab.ts
+++ b/src/settings/settings_tab.ts
@@ -9,7 +9,7 @@ import { FileSuggest } from "./ui/file_suggest";
 import { basicSetup } from "./ui/snippets_editor/extensions";
 import { getVimSelectModeCommand, vimCommand, getVimVisualModeCommand, getVimEditorCommands, getVimRunMatrixEnterCommand } from "src/features/editor_commands";
 import { LatexSuiteSettingsTab2, renderMarkdown } from "./settings_tab2";
-import {i18next} from "../i18n/i18n";
+import { settings_translation as t } from "../i18n/i18n"
 
 
 export class LatexSuiteSettingTab extends PluginSettingTab {
@@ -25,6 +25,11 @@ export class LatexSuiteSettingTab extends PluginSettingTab {
 
 	hide() {
 		this.snippetsEditor?.destroy();
+	}
+	async setControlValue(key: string, value: unknown): Promise<void> {
+		const settings = this.plugin.settings as unknown as Record<string, unknown>
+		settings[key] = value;
+		await this.plugin.saveSettings();
 	}
 
 	getSettingDefinitions(): SettingDefinitionItem[] {
@@ -142,7 +147,7 @@ export class LatexSuiteSettingTab extends PluginSettingTab {
 		const containerEl = this.containerEl;
 		this.addHeading(containerEl, "Conceal", "math-integral-x");
 
-		const fragment = renderMarkdown(this.app, i18next.t("conceal.enabled.desc"))
+		const fragment = renderMarkdown(this.app, t("conceal.enabled.desc"))
 		new Setting(containerEl)
 			.setName("Enabled")
 			.setDesc(fragment)
@@ -154,7 +159,7 @@ export class LatexSuiteSettingTab extends PluginSettingTab {
 				})
 			);
 
-		const fragment2 = renderMarkdown(this.app, i18next.t("conceal.reveal-delay.desc"))
+		const fragment2 = renderMarkdown(this.app, t("conceal.reveal-delay.desc"))
 		new Setting(containerEl)
 			.setName("Reveal delay (ms)")
 			.setDesc(fragment2)

--- a/src/settings/settings_tab2.ts
+++ b/src/settings/settings_tab2.ts
@@ -1,0 +1,849 @@
+import { App, ButtonComponent, Component, debounce, ExtraButtonComponent, MarkdownRenderer, Modal, Platform, Setting, SettingDefinition, SettingDefinitionControl, SettingDefinitionItem, SettingTab } from "obsidian"
+import { DEFAULT_SETTINGS, LatexSuitePluginSettings } from "./settings"
+import { i18next } from "../i18n/i18n"
+import { EditorState, Extension } from "@codemirror/state"
+import { EditorView, ViewUpdate } from "@codemirror/view"
+import { parseSnippetVariables, parseSnippets } from "src/snippets/parse"
+import { DEFAULT_SNIPPETS } from "src/utils/default_snippets"
+import { basicSetup } from "./ui/snippets_editor/extensions"
+import LatexSuitePlugin from "src/main"
+import { FileSuggest } from "./ui/file_suggest"
+
+
+type Definition<K> = K extends keyof LatexSuitePluginSettings ? SettingDefinition<K> : never
+type SnippetSettingDefinition = Definition<
+	| "snippetsEnabled"
+	| "snippets"
+	| "loadSnippetsFromFile"
+	| "snippetsFileLocation"
+>;
+
+type AdvancedSnippetSettingDefinition = Definition<
+	| "snippetVariables"
+	| "loadSnippetVariablesFromFile"
+	| "snippetVariablesFileLocation"
+	| "wordDelimiters"
+	| "removeSnippetWhitespace"
+	| "autoDelete$"
+	| "suppressIMEWarning"
+	| "suppressSnippetTriggerOnIME"
+	| "forceMathLanguages"
+	| "snippetDebug"
+>
+
+type ConcealSettingDefinition = Definition<
+	| "concealEnabled"
+	| "concealRevealTimeout"
+>
+
+type ColorHighlightSettingDefinition = Definition<
+	| "colorPairedBracketsEnabled"
+	| "highlightCursorBracketsEnabled"
+	| "highlightDollarEnabled"
+>
+
+type PopupPreviewSettingDefinition = Definition<
+	| "mathPreviewEnabled"
+	| "mathPreviewPositionIsAbove"
+	| "mathPreviewCursor"
+	| "mathPreviewBracketHighlighting"
+	| "mathPreviewLivePreviewDisplay"
+>
+
+type AutofractionSettingDefinition = Definition<
+	| "autofractionEnabled"
+	| "autofractionSymbol"
+	| "autofractionBreakingChars"
+	| "autofractionExcludedEnvs"
+>
+
+type MatrixShortcutsSettingDefinition = Definition<
+	| "matrixShortcutsEnabled"
+	| "matrixShortcutsEnvNames"
+	| "matrixShortcutsMacroNames"
+>
+
+type TaboutSettingDefinition = Definition<
+	| "taboutEnabled"
+	| "taboutClosingSymbols"
+	| "taboutExitEquationOnlyOnEOL"
+>
+
+type AutoEnlargeBracketsSettingDefinition = Definition<
+	| "autoEnlargeBrackets"
+	| "autoEnlargeBracketsTriggers"
+	| "autoEnlargeBracketsSpace"
+>
+
+type VimSettingDefinition = Definition<
+	| "vimEnabled"
+	| "vimSelectMode"
+	| "vimVisualMode"
+	| "vimMatrixEnter"
+>
+
+type ExperimentalSettingDefinition = Definition<
+	| "snippetRecursion"
+>
+
+
+export class LatexSuiteSettingsTab2 extends SettingTab {
+	snippetsEditor: EditorView | null = null;
+
+	constructor(
+		public app: App,
+		public plugin: LatexSuitePlugin,
+	) {
+		super();
+	}
+
+	getSettingDefinitions(): SettingDefinitionItem[] {
+		return [
+			...this.getSnippetDefinitions(),
+			...this.getConcealDefinitions(),
+			...this.getColorHighlightBracketsDefinitions(),
+			...this.getPopupPreviewDefinitions(),
+			...this.getAutofractionDefinitions(),
+			...this.getMatrixShortcutsDefinitions(),
+			...this.getTaboutDefinitions(),
+			...this.getAutoEnlargeBracketsDefinitions(),
+			...this.getVimSettingDefinitions(),
+			...this.getKeyMapDefinitions(),
+			...this.getExperimentalDefinitions(),
+		]
+	}
+
+	getSnippetDefinitions(): SettingDefinitionItem[] {
+		const snippets: SnippetSettingDefinition[] = [];
+		snippets.push(
+			{
+				name: i18next.t("snippets.enabled.name"),
+				desc: i18next.t("snippets.enabled.desc"),
+				control: {
+					type: "toggle",
+					key: "snippetsEnabled",
+					defaultValue: DEFAULT_SETTINGS.snippetsEnabled,
+				},
+			},
+			{
+				name: i18next.t("snippets.snippets.name"),
+				desc: i18next.t("snippets.snippets.desc"),
+				render: (setting) => {
+					setting.setClass("snippets-text-area");
+					this.snippetsEditor?.destroy()
+					this.snippetsEditor = createSnippetsEditor(setting, this.plugin);
+				},
+				visible: () => !this.plugin.settings.loadSnippetsFromFile,
+			},
+			{
+				name: i18next.t("snippets.load-from-file.name"),
+				desc: i18next.t("snippets.load-from-file.desc"),
+				control: {
+					key: "loadSnippetsFromFile",
+					type: "toggle",
+					defaultValue: DEFAULT_SETTINGS.loadSnippetsFromFile,
+				},
+			},
+			{
+				name: i18next.t("snippets.file-path.name"),
+				desc: i18next.t("snippets.file-path.desc"),
+				render: (setting) => {
+					this.fileSearch(setting, "snippetsFileLocation")
+				},
+				visible: () => this.plugin.settings.loadSnippetsFromFile,
+			},
+		);
+		const advanced: AdvancedSnippetSettingDefinition[] = [
+			{
+				name: i18next.t("advanced-snippets.variables.name"),
+				desc: i18next.t("advanced-snippets.variables.desc"),
+				render: (setting) => {
+					setting.addTextArea(text => text
+						.setValue(this.plugin.settings.snippetVariables)
+						.onChange(async (value) => {
+							this.plugin.settings.snippetVariables = value;
+							await this.plugin.saveSettings();
+						})
+						.setPlaceholder(DEFAULT_SETTINGS.snippetVariables))
+						.setClass("latex-suite-snippet-variables-setting");
+				},
+				visible: () => !this.plugin.settings.loadSnippetVariablesFromFile
+			},
+			{
+				name: i18next.t("advanced-snippets.load-variables-from-file.name"),
+				desc: i18next.t("advanced-snippets.load-variables-from-file.desc"),
+				control: getToggleControl("loadSnippetVariablesFromFile"),
+			},
+			{
+				name: i18next.t("advanced-snippets.variables-file-path.name"),
+				desc: i18next.t("advanced-snippets.variables-file-path.desc"),
+				render: (setting) => {
+					this.fileSearch(setting, "snippetVariablesFileLocation")
+				},
+				visible: () => this.plugin.settings.loadSnippetVariablesFromFile
+			},
+			{
+				name: i18next.t("advanced-snippets.word-delimiters.name"),
+				desc: i18next.t("advanced-snippets.word-delimiters.desc"),
+				control: {
+					type: "text",
+					key: "wordDelimiters",
+					defaultValue: DEFAULT_SETTINGS.wordDelimiters,
+				}
+			},
+			{
+				name: i18next.t("advanced-snippets.trailing-whitespace.name"),
+				desc: i18next.t("advanced-snippets.trailing-whitespace.desc"),
+				control: {
+					type: "toggle",
+					key: "removeSnippetWhitespace",
+					defaultValue: DEFAULT_SETTINGS.removeSnippetWhitespace,
+				}
+			},
+			{
+				name: i18next.t("advanced-snippets.auto-delete$.name"),
+				desc: i18next.t("advanced-snippets.auto-delete$.desc"),
+				control: {
+					type: "toggle",
+					key: "autoDelete$",
+					defaultValue: DEFAULT_SETTINGS.autoDelete$,
+				}
+			},
+			{
+				name: i18next.t("advanced-snippets.suppress-IME-warning.name"),
+				desc: i18next.t("advanced-snippets.suppress-IME-warning.desc"),
+				control: getToggleControl("suppressIMEWarning"),
+				visible: () => isIMESupported() && this.plugin.settings.suppressSnippetTriggerOnIME
+			},
+			{
+				name: i18next.t("advanced-snippets.suppress-IME.name"),
+				desc: i18next.t("advanced-snippets.suppress-IME.desc"),
+				control: getToggleControl("suppressSnippetTriggerOnIME"),
+			},
+			{
+				name: i18next.t("advanced-snippets.code-languages.name"),
+				desc: i18next.t("advanced-snippets.code-languages.desc"),
+				control: {
+					type: "text",
+					key: "forceMathLanguages",
+					defaultValue: DEFAULT_SETTINGS.forceMathLanguages,
+				}
+			},
+			{
+				name: i18next.t("advanced-snippets.snippet-debug-mode.name"),
+				desc: i18next.t("advanced-snippets.snippet-debug-mode.desc"),
+				control: {
+					type: "dropdown",
+					key: "snippetDebug",
+					options: {
+						off: i18next.t("advanced-snippets.snippet-debug-mode.options.off"),
+						info: i18next.t("advanced-snippets.snippet-debug-mode.options.info"),
+						verbose: i18next.t("advanced-snippets.snippet-debug-mode.options.verbose")
+					},
+					defaultValue: DEFAULT_SETTINGS.snippetDebug
+				}
+			}
+		]
+		return [{
+			type: "page",
+			name: i18next.t("snippets.heading"),
+			items: [...snippets, {
+				type: "group",
+				heading: i18next.t("advanced-snippets.heading"),
+				items: advanced
+			}],
+		}]
+	}
+
+	getConcealDefinitions(): SettingDefinitionItem[] {
+		const settings: ConcealSettingDefinition[] = [
+			{
+				name: i18next.t("conceal.enabled.name"),
+				desc: renderMarkdown(this.app, i18next.t("conceal.enabled.desc")),
+				control: {
+					type: "toggle",
+					key: "concealEnabled",
+					defaultValue: DEFAULT_SETTINGS.concealEnabled
+				}
+			},
+			{
+				name: i18next.t("conceal.reveal-delay.name"),
+				desc: renderMarkdown(this.app, i18next.t("conceal.reveal-delay.desc")),
+				control: {
+					type: "number",
+					key: "concealRevealTimeout",
+					defaultValue: DEFAULT_SETTINGS.concealRevealTimeout,
+					min: 0,
+				},
+			},
+		]
+		return [{
+			type: "page",
+			name: i18next.t("conceal.heading"),
+			items: settings,
+		}]
+	}
+
+	getColorHighlightBracketsDefinitions(): SettingDefinitionItem[] {
+		const settings: ColorHighlightSettingDefinition[] = [
+			{
+				name: i18next.t("highlight-brackets.color-brackets.name"),
+				desc: i18next.t("highlight-brackets.color-brackets.desc"),
+				control: {
+					type: "toggle",
+					key: "colorPairedBracketsEnabled",
+					defaultValue: DEFAULT_SETTINGS.colorPairedBracketsEnabled,
+				}
+			},
+			{
+				name: i18next.t("highlight-brackets.highlight-brackets.name"),
+				desc: i18next.t("highlight-brackets.highlight-brackets.desc"),
+				control: {
+					type: "toggle",
+					key: "highlightCursorBracketsEnabled",
+					defaultValue: DEFAULT_SETTINGS.highlightCursorBracketsEnabled,
+				}
+			},
+			{
+				name: i18next.t("highlight-brackets.color-math.name"),
+				desc: i18next.t("highlight-brackets.color-math.desc"),
+				control: {
+					type: "toggle",
+					key: "highlightDollarEnabled",
+					defaultValue: DEFAULT_SETTINGS.highlightDollarEnabled,
+				}
+			}
+		]
+		return [{
+			type: "page",
+			name: i18next.t("highlight-brackets.heading"),
+			items: settings
+		}]
+	}
+
+	getPopupPreviewDefinitions(): SettingDefinitionItem[] {
+		const settings: PopupPreviewSettingDefinition[] = [
+			{
+				name: i18next.t("math-preview.enabled.name"),
+				desc: renderMarkdown(this.app, i18next.t("math-preview.enabled.desc")),
+				control: {
+					type: "toggle",
+					key: "mathPreviewEnabled",
+					defaultValue: DEFAULT_SETTINGS.mathPreviewEnabled,
+				}
+			},
+			{
+				name: i18next.t("math-preview.position.name"),
+				desc: i18next.t("math-preview.position.desc"),
+				render: (setting) => {
+					setting.addDropdown((dropdown) => dropdown
+						.addOption("above", i18next.t("math-preview.position.options.above"))
+						.addOption("below", i18next.t("math-preview.position.options.below"))
+						.setValue(this.plugin.settings.mathPreviewPositionIsAbove ? "above" : "below")
+						.onChange(async (value) => {
+							this.plugin.settings.mathPreviewPositionIsAbove = value === "above";
+							await this.plugin.saveSettings();
+						})
+					)
+				}
+			},
+			{
+				name: i18next.t("math-preview.cursor-symbol.name"),
+				desc: i18next.t("math-preview.cursor-symbol.desc"),
+				render: (setting) => {
+					setting.addText(text => {
+						text
+							.setPlaceholder(DEFAULT_SETTINGS.mathPreviewCursor)
+							.setValue(this.plugin.settings.mathPreviewCursor)
+							.onChange(async (value) => {
+								this.plugin.settings.mathPreviewCursor = value;
+								await this.plugin.saveSettings();
+							});
+						const datalist = setting.controlEl.createEl("datalist", { attr: { id: "math-preview-cursor-list" } });
+						["▶", "┃", "|", "\\_", "{\\mid}", "{\\triangle}"].forEach(s => datalist.createEl("option", { value: s }));
+						text.inputEl.setAttribute("list", "math-preview-cursor-list");
+						return text;
+					});
+				}
+			},
+			{
+				name: i18next.t("math-preview.highlight-brackets.name"),
+				desc: i18next.t("math-preview.highlight-brackets.desc"),
+				control: {
+					type: "toggle",
+					key: "mathPreviewBracketHighlighting",
+					defaultValue: DEFAULT_SETTINGS.mathPreviewBracketHighlighting,
+				}
+			},
+			{
+				name: i18next.t("math-preview.display-live-preview.name"),
+				desc: i18next.t("math-preview.display-live-preview.desc"),
+				control: {
+					type: "toggle",
+					key: "mathPreviewLivePreviewDisplay",
+					defaultValue: DEFAULT_SETTINGS.mathPreviewLivePreviewDisplay,
+				}
+			}
+		]
+		return [{
+			type: "page",
+			name: i18next.t("math-preview.heading"),
+			items: settings,
+		}]
+	}
+
+	getAutofractionDefinitions(): SettingDefinitionItem[] {
+		const settings: AutofractionSettingDefinition[] = [
+			{
+				name: i18next.t("auto-fraction.enabled.name"),
+				desc: i18next.t("auto-fraction.enabled.desc"),
+				control: {
+					type: "toggle",
+					key: "autofractionEnabled",
+					defaultValue: DEFAULT_SETTINGS.autofractionEnabled,
+				}
+			},
+			{
+				name: i18next.t("auto-fraction.fraction-symbol.name"),
+				desc: renderMarkdown(this.app, i18next.t("auto-fraction.fraction-symbol.desc")),
+				render: (setting) => {
+					setting.addText(text => {
+						text
+							.setPlaceholder(DEFAULT_SETTINGS.autofractionSymbol)
+							.setValue(this.plugin.settings.autofractionSymbol)
+							.onChange(async (value) => {
+								this.plugin.settings.autofractionSymbol = value;
+
+								await this.plugin.saveSettings();
+							});
+
+						const datalist = setting.controlEl.createEl("datalist", { attr: { id: "autofraction-symbol-list" } });
+						["\\frac", "\\dfrac", "\\tfrac"].forEach(s => datalist.createEl("option", { value: s }));
+						text.inputEl.setAttribute("list", "autofraction-symbol-list");
+					});
+				}
+			},
+			{
+				name: i18next.t("auto-fraction.excluded-environments.name"),
+				desc: i18next.t("auto-fraction.excluded-environments.desc"),
+				control: {
+					key: "autofractionExcludedEnvs",
+					type: "textarea",
+					defaultValue: DEFAULT_SETTINGS.autofractionExcludedEnvs
+				}
+			},
+			{
+				name: i18next.t("auto-fraction.breaking-characters.name"),
+				desc: i18next.t("auto-fraction.breaking-characters.desc"),
+				control: {
+					key: "autofractionBreakingChars",
+					type: "text",
+					defaultValue: DEFAULT_SETTINGS.autofractionBreakingChars
+				}
+			}
+		]
+
+		return [{
+			type: "page",
+			name: i18next.t("auto-fraction.heading"),
+			items: settings,
+		}]
+	}
+
+	getMatrixShortcutsDefinitions(): SettingDefinitionItem[] {
+		const settings: MatrixShortcutsSettingDefinition[] = [
+			{
+				name: i18next.t("matrix-shortcuts.enabled.name"),
+				desc: i18next.t("matrix-shortcuts.enabled.desc"),
+				control: {
+					type: "toggle",
+					key: "matrixShortcutsEnabled",
+					defaultValue: DEFAULT_SETTINGS.matrixShortcutsEnabled,
+				}
+			},
+			{
+				name: i18next.t("matrix-shortcuts.environments.name"),
+				desc: i18next.t("matrix-shortcuts.environments.desc"),
+				control: {
+					key: "matrixShortcutsEnvNames",
+					type: "text",
+					defaultValue: DEFAULT_SETTINGS.matrixShortcutsEnvNames
+				}
+			},
+			{
+				name: i18next.t("matrix-shortcuts.macros.name"),
+				desc: i18next.t("matrix-shortcuts.macros.desc"),
+				control: {
+					key: "matrixShortcutsMacroNames",
+					type: "text",
+					defaultValue: DEFAULT_SETTINGS.matrixShortcutsMacroNames
+				}
+			}
+		]
+		return [{
+			type: "page",
+			name: i18next.t("matrix-shortcuts.heading"),
+			items: settings,
+		}]
+	}
+
+	getTaboutDefinitions(): SettingDefinitionItem[] {
+		const settings: TaboutSettingDefinition[] = [
+			{
+				name: i18next.t("tabout.enabled.name"),
+				desc: i18next.t("tabout.enabled.desc"),
+				control: {
+					type: "toggle",
+					key: "taboutEnabled",
+					defaultValue: DEFAULT_SETTINGS.taboutEnabled
+				}
+			},
+			{
+				name: i18next.t("tabout.closing-brackets.name"),
+				desc: i18next.t("tabout.closing-brackets.desc"),
+				control: {
+					type: "text",
+					key: "taboutClosingSymbols",
+					defaultValue: DEFAULT_SETTINGS.taboutClosingSymbols
+				}
+			},
+			{
+				name: i18next.t("tabout.exit-EOL.name"),
+				desc: i18next.t("tabout.exit-EOL.desc"),
+				control: {
+					type: "toggle",
+					key: "taboutExitEquationOnlyOnEOL",
+					defaultValue: DEFAULT_SETTINGS.taboutExitEquationOnlyOnEOL
+				}
+			}
+		]
+		return [{
+			type: "page",
+			name: i18next.t("tabout.heading"),
+			items: settings
+		}]
+	}
+
+	getAutoEnlargeBracketsDefinitions(): SettingDefinitionItem[] {
+		const settings: AutoEnlargeBracketsSettingDefinition[] = [
+			{
+				name: i18next.t("auto-enlarge.enabled.name"),
+				desc: i18next.t("auto-enlarge.enabled.desc"),
+				control: {
+					type: "toggle",
+					key: "autoEnlargeBrackets",
+					defaultValue: DEFAULT_SETTINGS.autoEnlargeBrackets
+				}
+			},
+			{
+				name: i18next.t("auto-enlarge.triggers.name"),
+				desc: i18next.t("auto-enlarge.triggers.desc"),
+				control: {
+					type: "text",
+					key: "autoEnlargeBracketsTriggers",
+					defaultValue: DEFAULT_SETTINGS.autoEnlargeBracketsTriggers
+				}
+			},
+			{
+				name: i18next.t("auto-enlarge.space.name"),
+				desc: i18next.t("auto-enlarge.space.desc"),
+				control: {
+					type: "toggle",
+					key: "autoEnlargeBracketsSpace",
+					defaultValue: DEFAULT_SETTINGS.autoEnlargeBracketsSpace
+				}
+			}
+		]
+		return [{
+			type: "page",
+			name: i18next.t("auto-enlarge.heading"),
+			items: settings,
+		}]
+	}
+
+	getVimSettingDefinitions(): SettingDefinitionItem[] {
+		const settings: VimSettingDefinition[] = [
+			{
+				name: i18next.t("vim.enabled.name"),
+				desc: i18next.t("vim.enabled.desc"),
+				control: getToggleControl("vimEnabled")
+			},
+			{
+				name: i18next.t("vim.select-mode.name"),
+				desc: i18next.t("vim.select-mode.desc"),
+				control: getTextControl("vimSelectMode"),
+			},
+			{
+				name: i18next.t("vim.visual-mode.name"),
+				desc: i18next.t("vim.visual-mode.desc"),
+				control: getTextControl("vimVisualMode"),
+			},
+			{
+				name: i18next.t("vim.matrix-enter.name"),
+				desc: i18next.t("vim.matrix-enter.desc"),
+				control: getTextControl("vimMatrixEnter"),
+			}
+		]
+		return [{
+			type: "page",
+			name: "Vim",
+			items: settings,
+		}]
+	}
+
+	getKeyMapDefinitions(): SettingDefinitionItem[] {
+		// typescript doesn't infer correctly here so using broader definition.
+		const settings: SettingDefinition[] = ([
+			["snippet", "snippetsTrigger"] ,
+			["next-tabstop", "snippetNextTabstopTrigger"] ,
+			["prev-tabstop", "snippetPreviousTabstopTrigger"] ,
+			["tabout", "taboutTrigger"] ,
+		] as const).map((keys) => ({
+			name: i18next.t(`keymap.${keys[0]}`),
+			control: {
+				type: "text",
+				key: keys[1],
+				defaultValue: DEFAULT_SETTINGS[keys[1]],
+		}}))
+		
+		return [{
+			type: "page",
+			name: i18next.t("keymap.heading.name"),
+			desc: i18next.t("keymap.heading.desc"),
+			items: [
+				{
+					name: " ",
+					desc: renderMarkdown(this.app, i18next.t("keymap.desc")),
+				},
+				{
+					type: "list",
+					items: settings,
+				},
+			],
+		}]
+	}
+	
+	getExperimentalDefinitions(): SettingDefinitionItem[] {
+		const settings: ExperimentalSettingDefinition[] = [
+			{
+				name: i18next.t("experimental.snippet-recursion.name"),
+				desc: renderMarkdown(this.app, i18next.t("experimental.snippet-recursion.desc")),
+				control: {
+					type: "number",
+					key: "snippetRecursion",
+					defaultValue: DEFAULT_SETTINGS.snippetRecursion,
+					min: 0,
+				}
+			}
+		]
+		
+
+		return [{
+			type: "page",
+			name: i18next.t("experimental.heading.name"),
+			items: settings,
+		}]
+	}
+
+	fileSearch(setting: Setting, key: "snippetsFileLocation" | "snippetVariablesFileLocation") {
+		setting.addSearch((component) => {
+			component
+				.setPlaceholder(DEFAULT_SETTINGS[key])
+				.setValue(this.plugin.settings[key])
+				.onChange(debounce(
+					async (value) => {
+						this.plugin.settings[key] = value;
+						await this.plugin.saveSettings(true);
+					},
+					500,
+					true,
+				));
+
+			let inputEl = component.inputEl;
+			inputEl.addClass("latex-suite-location-input-el");
+			new FileSuggest(this.app, inputEl);
+		});
+	}
+}
+
+function createSnippetsEditor(snippetsSetting: Setting, plugin: LatexSuitePlugin) {
+	const customCSSWrapper = snippetsSetting.controlEl.createDiv("snippets-editor-wrapper");
+	const snippetsFooter = snippetsSetting.controlEl.createDiv("snippets-footer");
+	const validity = snippetsFooter.createDiv("snippets-editor-validity");
+
+	const validityIndicator = new ExtraButtonComponent(validity);
+	validityIndicator.setIcon("checkmark")
+		.extraSettingsEl.addClass("snippets-editor-validity-indicator");
+
+	const validityText = validity.createDiv("snippets-editor-validity-text");
+	validityText.addClass("setting-item-description");
+
+	function updateValidityIndicator(success: boolean) {
+		validityIndicator.setIcon(success ? "checkmark" : "cross");
+		validityIndicator.extraSettingsEl.removeClass(success ? "invalid" : "valid");
+		validityIndicator.extraSettingsEl.addClass(success ? "valid" : "invalid");
+		validityText.setText(success ? "Saved" : "Invalid syntax. Changes not saved");
+	}
+
+
+	const extensions = [...basicSetup];
+
+	const change = EditorView.updateListener.of((v: ViewUpdate) => void (async () => {
+		if (v.docChanged) {
+			const snippets = v.state.doc.toString();
+			let success = true;
+
+			let snippetVariables;
+			try {
+				snippetVariables = await parseSnippetVariables(plugin.settings.snippetVariables, "snippet-variables.js");
+				await parseSnippets(snippets, snippetVariables, "snippets.js");
+			}
+			catch {
+				success = false;
+			}
+
+			updateValidityIndicator(success);
+
+			if (!success) return;
+
+			plugin.settings.snippets = snippets;
+			await plugin.saveSettings();
+		}
+	})());
+
+	extensions.push(change);
+
+	const snippetsEditor = createCMEditor(plugin.settings.snippets, extensions, customCSSWrapper);
+
+
+	const buttonsDiv = snippetsFooter.createDiv("snippets-editor-buttons");
+	const reset = new ButtonComponent(buttonsDiv);
+	reset.setIcon("switch")
+		.setTooltip("Reset to default snippets")
+		.onClick(async () => {
+			new ConfirmationModal(plugin.app,
+				"Are you sure? This will delete any custom snippets you have written.",
+				button => void button
+					.setButtonText("Reset to default snippets")
+					.setWarning(),
+				async () => {
+					snippetsEditor.setState(EditorState.create({ doc: DEFAULT_SNIPPETS, extensions: extensions }));
+					updateValidityIndicator(true);
+
+					plugin.settings.snippets = DEFAULT_SNIPPETS;
+
+					await plugin.saveSettings();
+				}
+			).open();
+		});
+
+	const remove = new ButtonComponent(buttonsDiv);
+	remove.setIcon("trash")
+		.setTooltip("Remove all snippets")
+		.onClick(async () => {
+			new ConfirmationModal(plugin.app,
+				"Are you sure? This will delete any custom snippets you have written.",
+				button => void button
+					.setButtonText("Remove all snippets")
+					.setWarning(),
+				async () => {
+					const value = `export default [
+
+]`;
+					snippetsEditor.setState(EditorState.create({ doc: value, extensions: extensions }));
+					updateValidityIndicator(true);
+
+					plugin.settings.snippets = value;
+					await plugin.saveSettings();
+				}
+			).open();
+		});
+	return snippetsEditor
+}
+
+class ConfirmationModal extends Modal {
+
+	constructor(app: App, body: string, buttonCallback: (button: ButtonComponent) => void, clickCallback: () => Promise<void>) {
+		super(app);
+
+		this.contentEl.addClass("latex-suite-confirmation-modal");
+		this.contentEl.createEl("p", { text: body });
+
+
+		new Setting(this.contentEl)
+			.addButton(button => {
+				buttonCallback(button);
+				button.onClick(async () => {
+					await clickCallback();
+					this.close();
+				});
+			})
+			.addButton(button => button
+				.setButtonText("Cancel")
+				.onClick(() => this.close()));
+	}
+}
+
+function createCMEditor(content: string, extensions: Extension[], node: Element) {
+	const view = new EditorView({
+		state: EditorState.create({ doc: content, extensions }),
+		parent: node,
+	});
+
+	return view;
+}
+
+/**
+ * IME support is tricky, currently only a fix for mobile platform is provided, update later if needed.
+ * @returns Whether IME keyboards are supported
+ */
+export function isIMESupported(): boolean {
+	return Platform.isMobileApp
+}
+function getTriggerHelpText(name: string) {
+	const fragment = new DocumentFragment();
+	fragment.createDiv({}, (div) => {
+		div.appendText(
+			`What key to press to trigger ${name}. Should follow codemirror keymap syntax such as "Ctrl-k Ctrl-a". For more info see `,
+		);
+		div.createEl("a", {
+			attr: { href: "https://codemirror.net/docs/ref/#view.KeyBinding" },
+			text: "codemirror keymap documentation",
+		});
+	});
+	return fragment;
+}
+
+export function renderMarkdown(app: App, markdown: string) {
+	const component = new Component()
+	const fragment = new DocumentFragment()
+	const span = fragment.createSpan()
+	void MarkdownRenderer.render(app, markdown, span, "", component).then(() => {
+		component.load()
+		component.unload()
+		// fragment.replaceChildren(...span.children)
+	})
+	return fragment
+}
+
+type toggles = keyof {
+	[K in keyof LatexSuitePluginSettings as LatexSuitePluginSettings[K] extends boolean ? K : never]: unknown
+};
+type textSettings = keyof {
+	[K in keyof LatexSuitePluginSettings as LatexSuitePluginSettings[K] extends string ? K : never]: unknown
+};
+
+function getToggleControl<T extends toggles>(key: T): SettingDefinitionControl<T>["control"] {
+	return {
+		type: "toggle",
+		key,
+		defaultValue: DEFAULT_SETTINGS[key],
+	}
+}
+function getTextControl<T extends textSettings>(key: T): SettingDefinitionControl<T>["control"] {
+	return {
+		type: "text",
+		key,
+		defaultValue: DEFAULT_SETTINGS[key],
+	}
+}

--- a/src/settings/settings_tab2.ts
+++ b/src/settings/settings_tab2.ts
@@ -1,13 +1,13 @@
-import { App, ButtonComponent, Component, debounce, ExtraButtonComponent, MarkdownRenderer, Modal, Platform, Setting, SettingDefinition, SettingDefinitionControl, SettingDefinitionItem, SettingTab } from "obsidian"
-import { DEFAULT_SETTINGS, LatexSuitePluginSettings } from "./settings"
-import { i18next } from "../i18n/i18n"
+import { App, ButtonComponent, Component, debounce, ExtraButtonComponent, MarkdownRenderer, Modal, Notice, Platform, Setting, SettingDefinition, SettingDefinitionControl, SettingDefinitionItem, SettingTab } from "obsidian"
+import { DEFAULT_SETTINGS, EnvironmentSchema, LatexSuitePluginSettings } from "./settings"
+import { settings_translation as t } from "../i18n/i18n"
 import { EditorState, Extension } from "@codemirror/state"
 import { EditorView, ViewUpdate } from "@codemirror/view"
 import { parseSnippetVariables, parseSnippets } from "src/snippets/parse"
-import { DEFAULT_SNIPPETS } from "src/utils/default_snippets"
 import { basicSetup } from "./ui/snippets_editor/extensions"
 import LatexSuitePlugin from "src/main"
 import { FileSuggest } from "./ui/file_suggest"
+import * as v from "valibot"
 
 
 type Definition<K> = K extends keyof LatexSuitePluginSettings ? SettingDefinition<K> : never
@@ -89,6 +89,8 @@ type ExperimentalSettingDefinition = Definition<
 
 export class LatexSuiteSettingsTab2 extends SettingTab {
 	snippetsEditor: EditorView | null = null;
+	snippetVariablesEditor: EditorView | null = null;
+	component = new Component();
 
 	constructor(
 		public app: App,
@@ -98,7 +100,8 @@ export class LatexSuiteSettingsTab2 extends SettingTab {
 	}
 
 	getSettingDefinitions(): SettingDefinitionItem[] {
-		return [
+		this.component.unload()
+		const definitions: SettingDefinitionItem[] = [
 			...this.getSnippetDefinitions(),
 			...this.getConcealDefinitions(),
 			...this.getColorHighlightBracketsDefinitions(),
@@ -111,42 +114,42 @@ export class LatexSuiteSettingsTab2 extends SettingTab {
 			...this.getKeyMapDefinitions(),
 			...this.getExperimentalDefinitions(),
 		]
+		this.component.load()
+		return definitions
 	}
 
 	getSnippetDefinitions(): SettingDefinitionItem[] {
 		const snippets: SnippetSettingDefinition[] = [];
 		snippets.push(
 			{
-				name: i18next.t("snippets.enabled.name"),
-				desc: i18next.t("snippets.enabled.desc"),
-				control: {
-					type: "toggle",
-					key: "snippetsEnabled",
-					defaultValue: DEFAULT_SETTINGS.snippetsEnabled,
-				},
+				name: t("snippets.enabled.name"),
+				desc: this.renderMarkdown( t("snippets.enabled.desc")),
+				control: getToggleControl("snippetsEnabled"),
 			},
 			{
-				name: i18next.t("snippets.snippets.name"),
-				desc: i18next.t("snippets.snippets.desc"),
+				name: t("snippets.snippets.name"),
+				desc: this.renderMarkdown(t("snippets.snippets.desc")),
 				render: (setting) => {
-					setting.setClass("snippets-text-area");
 					this.snippetsEditor?.destroy()
-					this.snippetsEditor = createSnippetsEditor(setting, this.plugin);
+					this.snippetsEditor = createSnippetsEditor(setting, this.plugin, {
+						type: "snippets",
+						validate: async (value) => {
+							const snippetVariables = await parseSnippetVariables(this.plugin.settings.snippetVariables, "snippet-variables.js");
+							await parseSnippets(value, snippetVariables, "snippets.js");
+						},
+						deleted: "export default [\n\n]"
+					});
 				},
 				visible: () => !this.plugin.settings.loadSnippetsFromFile,
 			},
 			{
-				name: i18next.t("snippets.load-from-file.name"),
-				desc: i18next.t("snippets.load-from-file.desc"),
-				control: {
-					key: "loadSnippetsFromFile",
-					type: "toggle",
-					defaultValue: DEFAULT_SETTINGS.loadSnippetsFromFile,
-				},
+				name: t("snippets.load-from-file.name"),
+				desc: this.renderMarkdown(t("snippets.load-from-file.desc")),
+				control: getToggleControl("loadSnippetsFromFile")
 			},
 			{
-				name: i18next.t("snippets.file-path.name"),
-				desc: i18next.t("snippets.file-path.desc"),
+				name: t("snippets.file-path.name"),
+				desc: this.renderMarkdown(t("snippets.file-path.desc")),
 				render: (setting) => {
 					this.fileSearch(setting, "snippetsFileLocation")
 				},
@@ -155,36 +158,36 @@ export class LatexSuiteSettingsTab2 extends SettingTab {
 		);
 		const advanced: AdvancedSnippetSettingDefinition[] = [
 			{
-				name: i18next.t("advanced-snippets.variables.name"),
-				desc: i18next.t("advanced-snippets.variables.desc"),
+				name: t("advanced-snippets.variables.name"),
+				desc: this.renderMarkdown(t("advanced-snippets.variables.desc")),
 				render: (setting) => {
-					setting.addTextArea(text => text
-						.setValue(this.plugin.settings.snippetVariables)
-						.onChange(async (value) => {
-							this.plugin.settings.snippetVariables = value;
-							await this.plugin.saveSettings();
-						})
-						.setPlaceholder(DEFAULT_SETTINGS.snippetVariables))
-						.setClass("latex-suite-snippet-variables-setting");
+					this.snippetVariablesEditor?.destroy()
+					this.snippetVariablesEditor = createSnippetsEditor(setting, this.plugin, {
+						type: "snippetVariables",
+						validate: async (value) => {
+							await parseSnippetVariables(value, "snippet-variables.js")
+						},
+						deleted: "export default {\n\n}"
+					})
 				},
 				visible: () => !this.plugin.settings.loadSnippetVariablesFromFile
 			},
 			{
-				name: i18next.t("advanced-snippets.load-variables-from-file.name"),
-				desc: i18next.t("advanced-snippets.load-variables-from-file.desc"),
+				name: t("advanced-snippets.load-variables-from-file.name"),
+				desc: this.renderMarkdown(t("advanced-snippets.load-variables-from-file.desc")),
 				control: getToggleControl("loadSnippetVariablesFromFile"),
 			},
 			{
-				name: i18next.t("advanced-snippets.variables-file-path.name"),
-				desc: i18next.t("advanced-snippets.variables-file-path.desc"),
+				name: t("advanced-snippets.variables-file-path.name"),
+				desc: this.renderMarkdown(t("advanced-snippets.variables-file-path.desc")),
 				render: (setting) => {
 					this.fileSearch(setting, "snippetVariablesFileLocation")
 				},
 				visible: () => this.plugin.settings.loadSnippetVariablesFromFile
 			},
 			{
-				name: i18next.t("advanced-snippets.word-delimiters.name"),
-				desc: i18next.t("advanced-snippets.word-delimiters.desc"),
+				name: t("advanced-snippets.word-delimiters.name"),
+				desc: this.renderMarkdown(t("advanced-snippets.word-delimiters.desc")),
 				control: {
 					type: "text",
 					key: "wordDelimiters",
@@ -192,53 +195,41 @@ export class LatexSuiteSettingsTab2 extends SettingTab {
 				}
 			},
 			{
-				name: i18next.t("advanced-snippets.trailing-whitespace.name"),
-				desc: i18next.t("advanced-snippets.trailing-whitespace.desc"),
-				control: {
-					type: "toggle",
-					key: "removeSnippetWhitespace",
-					defaultValue: DEFAULT_SETTINGS.removeSnippetWhitespace,
-				}
+				name: t("advanced-snippets.trailing-whitespace.name"),
+				desc: this.renderMarkdown(t("advanced-snippets.trailing-whitespace.desc")),
+				control: getToggleControl("removeSnippetWhitespace")
 			},
 			{
-				name: i18next.t("advanced-snippets.auto-delete$.name"),
-				desc: i18next.t("advanced-snippets.auto-delete$.desc"),
-				control: {
-					type: "toggle",
-					key: "autoDelete$",
-					defaultValue: DEFAULT_SETTINGS.autoDelete$,
-				}
+				name: t("advanced-snippets.auto-delete$.name"),
+				desc: this.renderMarkdown(t("advanced-snippets.auto-delete$.desc")),
+				control: getToggleControl("autoDelete$")
 			},
 			{
-				name: i18next.t("advanced-snippets.suppress-IME-warning.name"),
-				desc: i18next.t("advanced-snippets.suppress-IME-warning.desc"),
+				name: t("advanced-snippets.suppress-IME-warning.name"),
+				desc: this.renderMarkdown(t("advanced-snippets.suppress-IME-warning.desc")),
 				control: getToggleControl("suppressIMEWarning"),
 				visible: () => isIMESupported() && this.plugin.settings.suppressSnippetTriggerOnIME
 			},
 			{
-				name: i18next.t("advanced-snippets.suppress-IME.name"),
-				desc: i18next.t("advanced-snippets.suppress-IME.desc"),
+				name: t("advanced-snippets.suppress-IME.name"),
+				desc: this.renderMarkdown(t("advanced-snippets.suppress-IME.desc")),
 				control: getToggleControl("suppressSnippetTriggerOnIME"),
 			},
 			{
-				name: i18next.t("advanced-snippets.code-languages.name"),
-				desc: i18next.t("advanced-snippets.code-languages.desc"),
-				control: {
-					type: "text",
-					key: "forceMathLanguages",
-					defaultValue: DEFAULT_SETTINGS.forceMathLanguages,
-				}
+				name: t("advanced-snippets.code-languages.name"),
+				desc: this.renderMarkdown(t("advanced-snippets.code-languages.desc")),
+				control: getTextControl("forceMathLanguages")
 			},
 			{
-				name: i18next.t("advanced-snippets.snippet-debug-mode.name"),
-				desc: i18next.t("advanced-snippets.snippet-debug-mode.desc"),
+				name: t("advanced-snippets.snippet-debug-mode.name"),
+				desc: this.renderMarkdown(t("advanced-snippets.snippet-debug-mode.desc")),
 				control: {
 					type: "dropdown",
 					key: "snippetDebug",
 					options: {
-						off: i18next.t("advanced-snippets.snippet-debug-mode.options.off"),
-						info: i18next.t("advanced-snippets.snippet-debug-mode.options.info"),
-						verbose: i18next.t("advanced-snippets.snippet-debug-mode.options.verbose")
+						off: t("advanced-snippets.snippet-debug-mode.options.off"),
+						info: t("advanced-snippets.snippet-debug-mode.options.info"),
+						verbose: t("advanced-snippets.snippet-debug-mode.options.verbose")
 					},
 					defaultValue: DEFAULT_SETTINGS.snippetDebug
 				}
@@ -246,10 +237,10 @@ export class LatexSuiteSettingsTab2 extends SettingTab {
 		]
 		return [{
 			type: "page",
-			name: i18next.t("snippets.heading"),
+			name: t("snippets.heading"),
 			items: [...snippets, {
 				type: "group",
-				heading: i18next.t("advanced-snippets.heading"),
+				heading: t("advanced-snippets.heading"),
 				items: advanced
 			}],
 		}]
@@ -258,17 +249,13 @@ export class LatexSuiteSettingsTab2 extends SettingTab {
 	getConcealDefinitions(): SettingDefinitionItem[] {
 		const settings: ConcealSettingDefinition[] = [
 			{
-				name: i18next.t("conceal.enabled.name"),
-				desc: renderMarkdown(this.app, i18next.t("conceal.enabled.desc")),
-				control: {
-					type: "toggle",
-					key: "concealEnabled",
-					defaultValue: DEFAULT_SETTINGS.concealEnabled
-				}
+				name: t("conceal.enabled.name"),
+				desc: this.renderMarkdown( t("conceal.enabled.desc")),
+				control: getToggleControl("concealEnabled")
 			},
 			{
-				name: i18next.t("conceal.reveal-delay.name"),
-				desc: renderMarkdown(this.app, i18next.t("conceal.reveal-delay.desc")),
+				name: t("conceal.reveal-delay.name"),
+				desc: this.renderMarkdown( t("conceal.reveal-delay.desc")),
 				control: {
 					type: "number",
 					key: "concealRevealTimeout",
@@ -279,7 +266,7 @@ export class LatexSuiteSettingsTab2 extends SettingTab {
 		]
 		return [{
 			type: "page",
-			name: i18next.t("conceal.heading"),
+			name: t("conceal.heading"),
 			items: settings,
 		}]
 	}
@@ -287,36 +274,24 @@ export class LatexSuiteSettingsTab2 extends SettingTab {
 	getColorHighlightBracketsDefinitions(): SettingDefinitionItem[] {
 		const settings: ColorHighlightSettingDefinition[] = [
 			{
-				name: i18next.t("highlight-brackets.color-brackets.name"),
-				desc: i18next.t("highlight-brackets.color-brackets.desc"),
-				control: {
-					type: "toggle",
-					key: "colorPairedBracketsEnabled",
-					defaultValue: DEFAULT_SETTINGS.colorPairedBracketsEnabled,
-				}
+				name: t("highlight-brackets.color-brackets.name"),
+				desc: this.renderMarkdown(t("highlight-brackets.color-brackets.desc")),
+				control: getToggleControl("colorPairedBracketsEnabled")
 			},
 			{
-				name: i18next.t("highlight-brackets.highlight-brackets.name"),
-				desc: i18next.t("highlight-brackets.highlight-brackets.desc"),
-				control: {
-					type: "toggle",
-					key: "highlightCursorBracketsEnabled",
-					defaultValue: DEFAULT_SETTINGS.highlightCursorBracketsEnabled,
-				}
+				name: t("highlight-brackets.highlight-brackets.name"),
+				desc: this.renderMarkdown(t("highlight-brackets.highlight-brackets.desc")),
+				control: getToggleControl("highlightCursorBracketsEnabled")
 			},
 			{
-				name: i18next.t("highlight-brackets.color-math.name"),
-				desc: i18next.t("highlight-brackets.color-math.desc"),
-				control: {
-					type: "toggle",
-					key: "highlightDollarEnabled",
-					defaultValue: DEFAULT_SETTINGS.highlightDollarEnabled,
-				}
+				name: t("highlight-brackets.color-math.name"),
+				desc: this.renderMarkdown(t("highlight-brackets.color-math.desc")),
+				control: getToggleControl("highlightDollarEnabled")
 			}
 		]
 		return [{
 			type: "page",
-			name: i18next.t("highlight-brackets.heading"),
+			name: t("highlight-brackets.heading"),
 			items: settings
 		}]
 	}
@@ -324,21 +299,17 @@ export class LatexSuiteSettingsTab2 extends SettingTab {
 	getPopupPreviewDefinitions(): SettingDefinitionItem[] {
 		const settings: PopupPreviewSettingDefinition[] = [
 			{
-				name: i18next.t("math-preview.enabled.name"),
-				desc: renderMarkdown(this.app, i18next.t("math-preview.enabled.desc")),
-				control: {
-					type: "toggle",
-					key: "mathPreviewEnabled",
-					defaultValue: DEFAULT_SETTINGS.mathPreviewEnabled,
-				}
+				name: t("math-preview.enabled.name"),
+				desc: this.renderMarkdown( t("math-preview.enabled.desc")),
+				control: getToggleControl("mathPreviewEnabled")
 			},
 			{
-				name: i18next.t("math-preview.position.name"),
-				desc: i18next.t("math-preview.position.desc"),
+				name: t("math-preview.position.name"),
+				desc: this.renderMarkdown(t("math-preview.position.desc")),
 				render: (setting) => {
 					setting.addDropdown((dropdown) => dropdown
-						.addOption("above", i18next.t("math-preview.position.options.above"))
-						.addOption("below", i18next.t("math-preview.position.options.below"))
+						.addOption("above", t("math-preview.position.options.above"))
+						.addOption("below", t("math-preview.position.options.below"))
 						.setValue(this.plugin.settings.mathPreviewPositionIsAbove ? "above" : "below")
 						.onChange(async (value) => {
 							this.plugin.settings.mathPreviewPositionIsAbove = value === "above";
@@ -348,8 +319,8 @@ export class LatexSuiteSettingsTab2 extends SettingTab {
 				}
 			},
 			{
-				name: i18next.t("math-preview.cursor-symbol.name"),
-				desc: i18next.t("math-preview.cursor-symbol.desc"),
+				name: t("math-preview.cursor-symbol.name"),
+				desc: this.renderMarkdown(t("math-preview.cursor-symbol.desc")),
 				render: (setting) => {
 					setting.addText(text => {
 						text
@@ -367,27 +338,19 @@ export class LatexSuiteSettingsTab2 extends SettingTab {
 				}
 			},
 			{
-				name: i18next.t("math-preview.highlight-brackets.name"),
-				desc: i18next.t("math-preview.highlight-brackets.desc"),
-				control: {
-					type: "toggle",
-					key: "mathPreviewBracketHighlighting",
-					defaultValue: DEFAULT_SETTINGS.mathPreviewBracketHighlighting,
-				}
+				name: t("math-preview.highlight-brackets.name"),
+				desc: this.renderMarkdown(t("math-preview.highlight-brackets.desc")),
+				control: getToggleControl("mathPreviewBracketHighlighting")
 			},
 			{
-				name: i18next.t("math-preview.display-live-preview.name"),
-				desc: i18next.t("math-preview.display-live-preview.desc"),
-				control: {
-					type: "toggle",
-					key: "mathPreviewLivePreviewDisplay",
-					defaultValue: DEFAULT_SETTINGS.mathPreviewLivePreviewDisplay,
-				}
+				name: t("math-preview.display-live-preview.name"),
+				desc: this.renderMarkdown(t("math-preview.display-live-preview.desc")),
+				control: getToggleControl("mathPreviewLivePreviewDisplay")
 			}
 		]
 		return [{
 			type: "page",
-			name: i18next.t("math-preview.heading"),
+			name: t("math-preview.heading"),
 			items: settings,
 		}]
 	}
@@ -395,17 +358,13 @@ export class LatexSuiteSettingsTab2 extends SettingTab {
 	getAutofractionDefinitions(): SettingDefinitionItem[] {
 		const settings: AutofractionSettingDefinition[] = [
 			{
-				name: i18next.t("auto-fraction.enabled.name"),
-				desc: i18next.t("auto-fraction.enabled.desc"),
-				control: {
-					type: "toggle",
-					key: "autofractionEnabled",
-					defaultValue: DEFAULT_SETTINGS.autofractionEnabled,
-				}
+				name: t("auto-fraction.enabled.name"),
+				desc: this.renderMarkdown(t("auto-fraction.enabled.desc")),
+				control: getToggleControl("autofractionEnabled")
 			},
 			{
-				name: i18next.t("auto-fraction.fraction-symbol.name"),
-				desc: renderMarkdown(this.app, i18next.t("auto-fraction.fraction-symbol.desc")),
+				name: t("auto-fraction.fraction-symbol.name"),
+				desc: this.renderMarkdown( t("auto-fraction.fraction-symbol.desc")),
 				render: (setting) => {
 					setting.addText(text => {
 						text
@@ -424,17 +383,25 @@ export class LatexSuiteSettingsTab2 extends SettingTab {
 				}
 			},
 			{
-				name: i18next.t("auto-fraction.excluded-environments.name"),
-				desc: i18next.t("auto-fraction.excluded-environments.desc"),
+				name: t("auto-fraction.excluded-environments.name"),
+				desc: this.renderMarkdown(t("auto-fraction.excluded-environments.desc")),
 				control: {
 					key: "autofractionExcludedEnvs",
 					type: "textarea",
-					defaultValue: DEFAULT_SETTINGS.autofractionExcludedEnvs
-				}
+					defaultValue: DEFAULT_SETTINGS.autofractionExcludedEnvs,
+					validate: (value) => {
+						try {
+							v.parse(EnvironmentSchema, value);
+						} catch (e) {
+							console.error(e)
+							return "Invalid environment format. Error: " + (e as {message: string}).message;
+						}
+					}
+				},
 			},
 			{
-				name: i18next.t("auto-fraction.breaking-characters.name"),
-				desc: i18next.t("auto-fraction.breaking-characters.desc"),
+				name: t("auto-fraction.breaking-characters.name"),
+				desc: this.renderMarkdown(t("auto-fraction.breaking-characters.desc")),
 				control: {
 					key: "autofractionBreakingChars",
 					type: "text",
@@ -445,7 +412,7 @@ export class LatexSuiteSettingsTab2 extends SettingTab {
 
 		return [{
 			type: "page",
-			name: i18next.t("auto-fraction.heading"),
+			name: t("auto-fraction.heading"),
 			items: settings,
 		}]
 	}
@@ -453,17 +420,13 @@ export class LatexSuiteSettingsTab2 extends SettingTab {
 	getMatrixShortcutsDefinitions(): SettingDefinitionItem[] {
 		const settings: MatrixShortcutsSettingDefinition[] = [
 			{
-				name: i18next.t("matrix-shortcuts.enabled.name"),
-				desc: i18next.t("matrix-shortcuts.enabled.desc"),
-				control: {
-					type: "toggle",
-					key: "matrixShortcutsEnabled",
-					defaultValue: DEFAULT_SETTINGS.matrixShortcutsEnabled,
-				}
+				name: t("matrix-shortcuts.enabled.name"),
+				desc: this.renderMarkdown(t("matrix-shortcuts.enabled.desc")),
+				control: getToggleControl("matrixShortcutsEnabled")
 			},
 			{
-				name: i18next.t("matrix-shortcuts.environments.name"),
-				desc: i18next.t("matrix-shortcuts.environments.desc"),
+				name: t("matrix-shortcuts.environments.name"),
+				desc: this.renderMarkdown(t("matrix-shortcuts.environments.desc")),
 				control: {
 					key: "matrixShortcutsEnvNames",
 					type: "text",
@@ -471,8 +434,8 @@ export class LatexSuiteSettingsTab2 extends SettingTab {
 				}
 			},
 			{
-				name: i18next.t("matrix-shortcuts.macros.name"),
-				desc: i18next.t("matrix-shortcuts.macros.desc"),
+				name: t("matrix-shortcuts.macros.name"),
+				desc: this.renderMarkdown(t("matrix-shortcuts.macros.desc")),
 				control: {
 					key: "matrixShortcutsMacroNames",
 					type: "text",
@@ -482,7 +445,7 @@ export class LatexSuiteSettingsTab2 extends SettingTab {
 		]
 		return [{
 			type: "page",
-			name: i18next.t("matrix-shortcuts.heading"),
+			name: t("matrix-shortcuts.heading"),
 			items: settings,
 		}]
 	}
@@ -490,17 +453,13 @@ export class LatexSuiteSettingsTab2 extends SettingTab {
 	getTaboutDefinitions(): SettingDefinitionItem[] {
 		const settings: TaboutSettingDefinition[] = [
 			{
-				name: i18next.t("tabout.enabled.name"),
-				desc: i18next.t("tabout.enabled.desc"),
-				control: {
-					type: "toggle",
-					key: "taboutEnabled",
-					defaultValue: DEFAULT_SETTINGS.taboutEnabled
-				}
+				name: t("tabout.enabled.name"),
+				desc: this.renderMarkdown(t("tabout.enabled.desc")),
+				control: getToggleControl("taboutEnabled")
 			},
 			{
-				name: i18next.t("tabout.closing-brackets.name"),
-				desc: i18next.t("tabout.closing-brackets.desc"),
+				name: t("tabout.closing-brackets.name"),
+				desc: this.renderMarkdown(t("tabout.closing-brackets.desc")),
 				control: {
 					type: "text",
 					key: "taboutClosingSymbols",
@@ -508,18 +467,14 @@ export class LatexSuiteSettingsTab2 extends SettingTab {
 				}
 			},
 			{
-				name: i18next.t("tabout.exit-EOL.name"),
-				desc: i18next.t("tabout.exit-EOL.desc"),
-				control: {
-					type: "toggle",
-					key: "taboutExitEquationOnlyOnEOL",
-					defaultValue: DEFAULT_SETTINGS.taboutExitEquationOnlyOnEOL
-				}
+				name: t("tabout.exit-EOL.name"),
+				desc: this.renderMarkdown(t("tabout.exit-EOL.desc")),
+				control: getToggleControl("taboutExitEquationOnlyOnEOL")
 			}
 		]
 		return [{
 			type: "page",
-			name: i18next.t("tabout.heading"),
+			name: t("tabout.heading"),
 			items: settings
 		}]
 	}
@@ -527,17 +482,13 @@ export class LatexSuiteSettingsTab2 extends SettingTab {
 	getAutoEnlargeBracketsDefinitions(): SettingDefinitionItem[] {
 		const settings: AutoEnlargeBracketsSettingDefinition[] = [
 			{
-				name: i18next.t("auto-enlarge.enabled.name"),
-				desc: i18next.t("auto-enlarge.enabled.desc"),
-				control: {
-					type: "toggle",
-					key: "autoEnlargeBrackets",
-					defaultValue: DEFAULT_SETTINGS.autoEnlargeBrackets
-				}
+				name: t("auto-enlarge.enabled.name"),
+				desc: this.renderMarkdown(t("auto-enlarge.enabled.desc")),
+				control: getToggleControl("autoEnlargeBrackets")
 			},
 			{
-				name: i18next.t("auto-enlarge.triggers.name"),
-				desc: i18next.t("auto-enlarge.triggers.desc"),
+				name: t("auto-enlarge.triggers.name"),
+				desc: this.renderMarkdown(t("auto-enlarge.triggers.desc")),
 				control: {
 					type: "text",
 					key: "autoEnlargeBracketsTriggers",
@@ -545,18 +496,14 @@ export class LatexSuiteSettingsTab2 extends SettingTab {
 				}
 			},
 			{
-				name: i18next.t("auto-enlarge.space.name"),
-				desc: i18next.t("auto-enlarge.space.desc"),
-				control: {
-					type: "toggle",
-					key: "autoEnlargeBracketsSpace",
-					defaultValue: DEFAULT_SETTINGS.autoEnlargeBracketsSpace
-				}
+				name: t("auto-enlarge.space.name"),
+				desc: this.renderMarkdown(t("auto-enlarge.space.desc")),
+				control: getToggleControl("autoEnlargeBracketsSpace")
 			}
 		]
 		return [{
 			type: "page",
-			name: i18next.t("auto-enlarge.heading"),
+			name: t("auto-enlarge.heading"),
 			items: settings,
 		}]
 	}
@@ -564,23 +511,23 @@ export class LatexSuiteSettingsTab2 extends SettingTab {
 	getVimSettingDefinitions(): SettingDefinitionItem[] {
 		const settings: VimSettingDefinition[] = [
 			{
-				name: i18next.t("vim.enabled.name"),
-				desc: i18next.t("vim.enabled.desc"),
+				name: t("vim.enabled.name"),
+				desc: this.renderMarkdown(t("vim.enabled.desc")),
 				control: getToggleControl("vimEnabled")
 			},
 			{
-				name: i18next.t("vim.select-mode.name"),
-				desc: i18next.t("vim.select-mode.desc"),
+				name: t("vim.select-mode.name"),
+				desc: this.renderMarkdown(t("vim.select-mode.desc")),
 				control: getTextControl("vimSelectMode"),
 			},
 			{
-				name: i18next.t("vim.visual-mode.name"),
-				desc: i18next.t("vim.visual-mode.desc"),
+				name: t("vim.visual-mode.name"),
+				desc: this.renderMarkdown(t("vim.visual-mode.desc")),
 				control: getTextControl("vimVisualMode"),
 			},
 			{
-				name: i18next.t("vim.matrix-enter.name"),
-				desc: i18next.t("vim.matrix-enter.desc"),
+				name: t("vim.matrix-enter.name"),
+				desc: this.renderMarkdown(t("vim.matrix-enter.desc")),
 				control: getTextControl("vimMatrixEnter"),
 			}
 		]
@@ -599,7 +546,7 @@ export class LatexSuiteSettingsTab2 extends SettingTab {
 			["prev-tabstop", "snippetPreviousTabstopTrigger"] ,
 			["tabout", "taboutTrigger"] ,
 		] as const).map((keys) => ({
-			name: i18next.t(`keymap.${keys[0]}`),
+			name: t(`keymap.${keys[0]}`),
 			control: {
 				type: "text",
 				key: keys[1],
@@ -608,12 +555,12 @@ export class LatexSuiteSettingsTab2 extends SettingTab {
 		
 		return [{
 			type: "page",
-			name: i18next.t("keymap.heading.name"),
-			desc: i18next.t("keymap.heading.desc"),
+			name: t("keymap.heading.name"),
+			desc: this.renderMarkdown(t("keymap.heading.desc")),
 			items: [
 				{
 					name: " ",
-					desc: renderMarkdown(this.app, i18next.t("keymap.desc")),
+					desc: this.renderMarkdown( t("keymap.desc")),
 				},
 				{
 					type: "list",
@@ -626,8 +573,8 @@ export class LatexSuiteSettingsTab2 extends SettingTab {
 	getExperimentalDefinitions(): SettingDefinitionItem[] {
 		const settings: ExperimentalSettingDefinition[] = [
 			{
-				name: i18next.t("experimental.snippet-recursion.name"),
-				desc: renderMarkdown(this.app, i18next.t("experimental.snippet-recursion.desc")),
+				name: t("experimental.snippet-recursion.name"),
+				desc: this.renderMarkdown( t("experimental.snippet-recursion.desc")),
 				control: {
 					type: "number",
 					key: "snippetRecursion",
@@ -640,7 +587,7 @@ export class LatexSuiteSettingsTab2 extends SettingTab {
 
 		return [{
 			type: "page",
-			name: i18next.t("experimental.heading.name"),
+			name: t("experimental.heading.name"),
 			items: settings,
 		}]
 	}
@@ -664,15 +611,45 @@ export class LatexSuiteSettingsTab2 extends SettingTab {
 			new FileSuggest(this.app, inputEl);
 		});
 	}
+
+	renderMarkdown(source: string) {
+		const fragment = new DocumentFragment()
+		const span = fragment.createSpan()
+		// Don't render right on startup, but have something rendered.
+		span.setText(source)
+		void MarkdownRenderer.render(this.app, source, span, "", this.component).then(() => {
+			span.replaceChildren(...Array.from(span.children).map(child => {
+				if (child.tagName === "P") {
+					child.addClass("latex-suite-markdown-p")
+				}
+				return child
+			})
+			)
+		})
+		return fragment
+	}
 }
 
-function createSnippetsEditor(snippetsSetting: Setting, plugin: LatexSuitePlugin) {
-	const customCSSWrapper = snippetsSetting.controlEl.createDiv("snippets-editor-wrapper");
-	const snippetsFooter = snippetsSetting.controlEl.createDiv("snippets-footer");
+function createSnippetsEditor(
+	snippetsSetting: Setting,
+	plugin: LatexSuitePlugin,
+	config: {
+		type: "snippets" | "snippetVariables";
+		validate: (value: string) => Promise<void>;
+		deleted: string;
+	},
+): EditorView {
+	snippetsSetting.setClass("snippets-text-area");
+	const customCSSWrapper = snippetsSetting.controlEl.createDiv(
+		"snippets-editor-wrapper",
+	);
+	const snippetsFooter =
+		snippetsSetting.controlEl.createDiv("snippets-footer");
 	const validity = snippetsFooter.createDiv("snippets-editor-validity");
 
 	const validityIndicator = new ExtraButtonComponent(validity);
-	validityIndicator.setIcon("checkmark")
+	validityIndicator
+		.setIcon("checkmark")
 		.extraSettingsEl.addClass("snippets-editor-validity-indicator");
 
 	const validityText = validity.createDiv("snippets-editor-validity-text");
@@ -680,85 +657,112 @@ function createSnippetsEditor(snippetsSetting: Setting, plugin: LatexSuitePlugin
 
 	function updateValidityIndicator(success: boolean) {
 		validityIndicator.setIcon(success ? "checkmark" : "cross");
-		validityIndicator.extraSettingsEl.removeClass(success ? "invalid" : "valid");
-		validityIndicator.extraSettingsEl.addClass(success ? "valid" : "invalid");
-		validityText.setText(success ? "Saved" : "Invalid syntax. Changes not saved");
+		validityIndicator.extraSettingsEl.removeClass(
+			success ? "invalid" : "valid",
+		);
+		validityIndicator.extraSettingsEl.addClass(
+			success ? "valid" : "invalid",
+		);
+		validityText.setText(
+			success ? "Saved" : "Invalid syntax. Changes not saved",
+		);
 	}
 
-
 	const extensions = [...basicSetup];
+	
+	const debouncedValidityIndicator = debounce(async (state: EditorState) => {
+		const snippets = state.doc.toString();
+		let success = true;
 
-	const change = EditorView.updateListener.of((v: ViewUpdate) => void (async () => {
-		if (v.docChanged) {
-			const snippets = v.state.doc.toString();
-			let success = true;
-
-			let snippetVariables;
-			try {
-				snippetVariables = await parseSnippetVariables(plugin.settings.snippetVariables, "snippet-variables.js");
-				await parseSnippets(snippets, snippetVariables, "snippets.js");
-			}
-			catch {
-				success = false;
-			}
-
-			updateValidityIndicator(success);
-
-			if (!success) return;
-
-			plugin.settings.snippets = snippets;
-			await plugin.saveSettings();
+		try {
+			await config.validate(snippets);
+		} catch {
+			success = false;
 		}
-	})());
+
+		updateValidityIndicator(success);
+
+		if (!success) return;
+
+		plugin.settings[config.type] = snippets;
+		await plugin.saveSettings();
+	}, 500);
+
+	const change = EditorView.updateListener.of(
+		(v: ViewUpdate) =>
+			void (async () => {
+		if (v.docChanged) {
+			debouncedValidityIndicator(v.state);
+		}
+			})(),
+	);
 
 	extensions.push(change);
 
-	const snippetsEditor = createCMEditor(plugin.settings.snippets, extensions, customCSSWrapper);
-
+	const snippetsEditor = createCMEditor(
+		plugin.settings[config.type],
+		extensions,
+		customCSSWrapper,
+	);
 
 	const buttonsDiv = snippetsFooter.createDiv("snippets-editor-buttons");
 	const reset = new ButtonComponent(buttonsDiv);
-	reset.setIcon("switch")
+	reset
+		.setIcon("switch")
 		.setTooltip("Reset to default snippets")
 		.onClick(async () => {
-			new ConfirmationModal(plugin.app,
+			new ConfirmationModal(
+				plugin.app,
 				"Are you sure? This will delete any custom snippets you have written.",
-				button => void button
+				(button) =>
+					void button
 					.setButtonText("Reset to default snippets")
 					.setWarning(),
 				async () => {
-					snippetsEditor.setState(EditorState.create({ doc: DEFAULT_SNIPPETS, extensions: extensions }));
+					snippetsEditor.setState(
+						EditorState.create({
+							doc: DEFAULT_SETTINGS[config.type],
+							extensions: extensions,
+						}),
+					);
 					updateValidityIndicator(true);
 
-					plugin.settings.snippets = DEFAULT_SNIPPETS;
+					plugin.settings[config.type] =
+						DEFAULT_SETTINGS[config.type];
 
 					await plugin.saveSettings();
-				}
+				},
 			).open();
 		});
 
 	const remove = new ButtonComponent(buttonsDiv);
-	remove.setIcon("trash")
+	remove
+		.setIcon("trash")
 		.setTooltip("Remove all snippets")
 		.onClick(async () => {
-			new ConfirmationModal(plugin.app,
+			new ConfirmationModal(
+				plugin.app,
 				"Are you sure? This will delete any custom snippets you have written.",
-				button => void button
+				(button) =>
+					void button
 					.setButtonText("Remove all snippets")
 					.setWarning(),
 				async () => {
-					const value = `export default [
-
-]`;
-					snippetsEditor.setState(EditorState.create({ doc: value, extensions: extensions }));
+					const value = config.deleted
+					snippetsEditor.setState(
+						EditorState.create({
+							doc: value,
+							extensions: extensions,
+						}),
+					);
 					updateValidityIndicator(true);
 
-					plugin.settings.snippets = value;
+					plugin.settings[config.type] = value;
 					await plugin.saveSettings();
-				}
+				},
 			).open();
 		});
-	return snippetsEditor
+	return snippetsEditor;
 }
 
 class ConfirmationModal extends Modal {
@@ -818,11 +822,17 @@ export function renderMarkdown(app: App, markdown: string) {
 	const component = new Component()
 	const fragment = new DocumentFragment()
 	const span = fragment.createSpan()
+	span.setText(markdown)
 	void MarkdownRenderer.render(app, markdown, span, "", component).then(() => {
-		component.load()
-		component.unload()
-		// fragment.replaceChildren(...span.children)
+		span.replaceChildren(...Array.from(span.children).map(child => {
+			if (child.tagName === "P") {
+				child.addClass("latex-suite-markdown-p")
+			}
+			return child
+		})
+		)
 	})
+	component.unload()
 	return fragment
 }
 

--- a/styles.css
+++ b/styles.css
@@ -17,25 +17,17 @@
     border-top: none;
 }
 
-.setting-item.setting-item-heading:has(.latex-suite-settings-icon) ~ .setting-item:not(.setting-item-heading), .latex-suite-snippet-variables-setting + .setting-item-control {
+.setting-item.setting-item-heading:has(.latex-suite-settings-icon) ~ .setting-item:not(.setting-item-heading) {
     width: calc(100% - 26px);
     margin-left: 26px;
 }
 
-.latex-suite-snippet-variables-setting .setting-item-control {
-    height: 120px;
-}
-
-.latex-suite-snippet-variables-setting .setting-item-control textarea {
-    width: 100%;
-    height: 100%;
-}
-
-.snippets-text-area, .latex-suite-snippet-variables-setting {
+.snippets-text-area {
     display: inline-block;
+	width: 100%;
 }
 
-.snippets-text-area .setting-item-info, .latex-suite-snippet-variables-setting .setting-item-info {
+.snippets-text-area .setting-item-info {
     margin-bottom: 0.75rem;
 }
 
@@ -289,4 +281,12 @@ and limit the height.
 
 .latex-suite-highlighted-dollar-code {
 	color: #54940b;
+}
+
+p.latex-suite-markdown-p {
+	margin-block-end: 0px;
+}
+
+span > p.latex-suite-markdown-p:first-child {
+	margin-block-start: 0px;
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,6 +10,8 @@
     "noImplicitAny": true,
 	"strictNullChecks": true,
     "moduleResolution": "node",
+	"ignoreDeprecations": "6.0",
+	"resolveJsonModule": true,
     "importHelpers": true,
     "isolatedModules": true,
     "lib": [


### PR DESCRIPTION
migrate and add support for translations.

The descriptions that were html, are converted to markdown.
But they still contain mostly html as the `p` tag creates a lot of space above