### PR TITLE
fix: treat begin as command

### DIFF
--- a/src/utils/context.ts
+++ b/src/utils/context.ts
@@ -223,7 +223,7 @@ export class Context implements PluginValue {
 			return createEnvironment(node);
 		} else if (value === "KnownEnvironment") {
 			return createEnvironment(node.firstChild);
-		} else if (value.endsWith("Argument")) {
+		} else if (value.endsWith("Argument") || value === "EnvNameGroup") {
 			const parent = node.parent;
 			const command = parent?.firstChild;
 			const openBraced = node?.firstChild;

--- a/tests/context-snippets.ts
+++ b/tests/context-snippets.ts
@@ -13,6 +13,8 @@ export const names = [
 	["math", "m"],
 	["math-exclude-pu", "m"],
 	["math-exclude-align", "m"],
+	["math-include-begin", "m"],
+	["math-include-color", "m"],
 ] as const;
 
 const normal_name_options = [
@@ -75,31 +77,68 @@ export const transactionSpec: Spec[] = [
 		pos: "$$\\begin{align}a&=b\\\\c&=d".length,
 		options: ["M", "m"],
 		names: ["display-math", "math", "math-exclude-pu"],
+	},
+	// snippetless envs
+	{
+		text: "$$\\begin{align}a&=b\\\\c&=d\\end{align}$$",
+		pos: "$$\\begin{align".length,
+		options: ["m"],
+		names: ["math-include-begin"]
+	},
+	{
+		text: "$$\\color{}$$",
+		pos: "$$\\color{".length,
+		options: ["m"],
+		names: ["math-include-color"]
 	}
 ];
 
 let length = normal_name_options.length;
-const snippets = [
-	...normal_name_options.slice(0, length).map((value, index) => ({
-		trigger: index.toString(),
-		replacement: "",
-		options: value[1],
-		name: value[0],
-	})),
-	{
-		trigger: (length++).toString(),
-		replacement: "",
-		options: "m",
-		name: "math-exclude-pu",
-		excludedMacros: ["pu"],
-	},
-	{
-		trigger: (length++).toString(),
-		replacement: "",
-		options: "m",
-		name: "math-exclude-align",
-		excludedEnvironments: ["align"],
-	}
-] satisfies (RawSnippet & { name: typeof names[number]["0"] })[];
+const snippets = (
+	[
+		...normal_name_options.slice(0, length).map((value, index) => ({
+			trigger: index.toString(),
+			replacement: "",
+			options: value[1],
+			name: value[0],
+		})),
+		{
+			trigger: (length++).toString(),
+			replacement: "",
+			options: "m",
+			name: "math-exclude-pu",
+			excludedMacros: ["pu"],
+		},
+		{
+			trigger: (length++).toString(),
+			replacement: "",
+			options: "m",
+			name: "math-exclude-align",
+			excludedEnvironments: ["align"],
+		},
+		{
+			trigger: (length++).toString(),
+			replacement: "",
+			options: "m",
+			name: "math-include-color",
+			includedMacros: ["color"],
+		},
+		{
+			trigger: (length++).toString(),
+			replacement: "",
+			options: "m",
+			name: "math-include-begin",
+			includedMacros: ["begin"],
+		},
+	] as const
+).map(
+	(snippet) =>
+		({
+			...snippet,
+			trigger: new RegExp(`(?<!\\d)${snippet.trigger}`),
+		}) as const,
+) satisfies (Readonly<RawSnippet> & {
+	readonly name: (typeof names)[number]["0"];
+})[];
 
 export default snippets;

--- a/tests/main.ts
+++ b/tests/main.ts
@@ -1,9 +1,9 @@
-import LatexSuitePlugin from "../src/main.js";
-import { fullMathParser } from "../src/parser/mathjax-parser.js";
-import { conceal } from "../src/editor_extensions/conceal_fns.js";
+import LatexSuitePlugin from "../src/main";
+import { fullMathParser } from "../src/parser/mathjax-parser";
+import { conceal } from "../src/editor_extensions/conceal_fns";
 import { MarkdownView } from "obsidian";
 import { EditorView } from "@codemirror/view";
-import { RawSnippetSchema } from "../src/snippets/parse.js";
+import { RawSnippetSchema } from "../src/snippets/parse";
 import * as v from "valibot"
 
 declare global {

--- a/tests/snippet-env.test.ts
+++ b/tests/snippet-env.test.ts
@@ -1,4 +1,4 @@
-import { beforeAll, describe, it } from "vitest";
+import { beforeAll, describe, expect, it } from "vitest";
 import { ContextId, evalInObsidian, registerLibResolver } from "obsidian-integration-testing";
 import type TestPlugin from "./main";
 import { type MarkdownView, type TFile } from "obsidian";
@@ -6,7 +6,7 @@ import { type EditorView } from "@codemirror/view";
 import { readFileSync } from "fs";
 import * as ts from "typescript"
 import { getTemporaryVault } from "obsidian-integration-testing/vitest-global-setup-plugin";
-
+import context_snippets, { transactionSpec } from "./context-snippets"
 interface FileContext {
 	file: TFile;
 	snippets: TFile;
@@ -47,6 +47,9 @@ describe("snippet environment options", () => {
 				if (window.__latex_suite_test_library.view?.state.field(obsidianModule.editorLivePreviewField)) {
 					app.commands.executeCommandById("editor:toggle-source");
 				}
+				plugin.settings.snippetsFileLocation = context.snippets.path;
+				plugin.settings.loadSnippetsFromFile = true;
+				await plugin.saveSettings();
 			},
 		});
 	});
@@ -59,6 +62,47 @@ describe("snippet environment options", () => {
 			target: ts.ScriptTarget.ESNext,
 			moduleResolution: ts.ModuleResolutionKind.NodeNext,	
 		});
-		console.log(compiled_raw_snippets)
-	});
+		const result = await evalInObsidian({
+			contextId,
+			callback: async ({
+				app,
+				context,
+				lib: { view, plugin, pressKey },
+				compiled_raw_snippets,
+				transactionSpec,
+				context_snippets,
+			}) => {
+				await app.vault.modify(context.snippets, compiled_raw_snippets);
+				// speed up the test by disabling math preview and conceal.
+				plugin.settings.mathPreviewEnabled = false;
+				plugin.settings.concealEnabled = false;
+				await plugin.saveSettings();
+				const results = [];
+				for (const spec of transactionSpec) {
+					for (let i=0; i < context_snippets.length; i++) {
+						const snippet = context_snippets[i];
+						const pos = spec.pos;
+						const text = spec.text.slice(0, pos) + i.toString() + spec.text.slice(pos);
+						const new_pos = pos + i.toString().length;
+						view.setDoc(text, new_pos);
+						pressKey({ key: "Tab" });
+						// let the transaction finish first.
+						await new Promise((resolve) => setTimeout(resolve, 0));
+						const changed_doc = view.state.doc.toString();
+						const trigger = snippet.trigger;
+						const info = { snippet: snippet.name, applied: false, text: changed_doc, old_text: text, trigger };
+						if (spec.names.includes(snippet.name) && changed_doc !== spec.text) {
+							info.applied = true;
+							results.push(info);
+						} else if (!spec.names.includes(snippet.name) && changed_doc === spec.text) {
+							results.push(info);
+						}
+					}
+				}
+				return results;
+			},
+			input: { compiled_raw_snippets, context_snippets, transactionSpec },
+		});
+		expect(result).toStrictEqual([]);
+	}, 20_000);
 });


### PR DESCRIPTION
`\begin` and `\end` have a different name/argument structure in the parser causing it not to be recognized as a macro and thus is treated as math while it should be snippetless.