### PR TITLE
fix: parser obsidian comments

### DIFF
--- a/src/parser/mathjax-parser.ts
+++ b/src/parser/mathjax-parser.ts
@@ -379,6 +379,7 @@ const obsidianCommentParser: MarkdownConfig = {
 					const endPos = cx.lineStart + end + 2
 					cx.addElement(cx.elt(Type.ObsidianComment, startPos, endPos));
 					cx.parser.parseInline(line.text.slice(end + 2), endPos).map(marker => cx.addElement(marker));
+					cx.nextLine();
 					return true;
 				}
 				return false;

--- a/tests/__snapshots__/mathjax-parser.test.ts.snap
+++ b/tests/__snapshots__/mathjax-parser.test.ts.snap
@@ -1,0 +1,3 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`my-plugin > should parse markdown after obsidian multiline comment (#634) 1`] = `"Document(Paragraph(DollarInlineMath(Dollar,LaTeX(Math(MathChar,Group(OpenBrace,Math(MathChar),CloseBrace),Group(OpenBrace,Math(MathChar),CloseBrace))),Dollar)),ObsidianComment,Paragraph(DollarInlineMath(Dollar,LaTeX(Math(MathChar,MathSpecialChar,MathChar)),Dollar)))"`;

--- a/tests/mathjax-parser.test.ts
+++ b/tests/mathjax-parser.test.ts
@@ -74,7 +74,7 @@ obsidian display comment
 				return parsed.toString();
 			},
 		});
-		expect(result).toBe("Document(Paragraph(ObsidianComment,DollarInlineMath(Dollar,LaTeX(Math(MathChar,MathSpecialChar,Number)),Dollar)),ObsidianComment,DollarInlineMath(Dollar,LaTeX(Math(MathChar,MathSpecialChar,Number)),Dollar),Paragraph)")
+		expect(result).toBe("Document(Paragraph(ObsidianComment,DollarInlineMath(Dollar,LaTeX(Math(MathChar,MathSpecialChar,Number)),Dollar)),ObsidianComment,DollarInlineMath(Dollar,LaTeX(Math(MathChar,MathSpecialChar,Number)),Dollar))")
 	})
 	
 	it("parser: html comment with markdown at then end", async () => {
@@ -119,6 +119,26 @@ display html comment
 			},
 		});
 		expect(result).toBe("Document(Table(TableHeader(TableDelimiter,TableCell(DollarInlineMath(Dollar,LaTeX(Math(MathChar,MathSpecialChar,Number)),Dollar)),TableDelimiter,TableCell(DollarInlineMath(Dollar,LaTeX(Math(MathChar,MathSpecialChar,Number)),Dollar)),TableDelimiter),TableDelimiter,TableRow(TableDelimiter,TableCell(DollarInlineMath(Dollar,LaTeX(Math(MathChar,MathSpecialChar,Number)),Dollar)),TableDelimiter,TableCell(DollarInlineMath(Dollar,LaTeX(Math(MathChar,MathSpecialChar,Number)),Dollar)),TableDelimiter)))")
+	})
+	
+	it("should parse markdown after obsidian multiline comment (#634)", async () => {
+		const result = await evalInObsidian({
+			input: { pluginId: "obsidian-latex-suite" },
+			callback: ({ app, pluginId }) => {
+				const plugin = app.plugins.getPlugin(pluginId) as TestPlugin;
+				const parser = plugin.test.parser(["math"]);
+				return parser.parse(
+`
+$\frac{a}{b}$
+%%
+multi-line comment
+%%
+$a/b$
+`
+				).toString();
+			}
+		})	
+		expect(result).toMatchSnapshot();
 	})
 
 });


### PR DESCRIPTION
Fixes #634

markdown after multiline obsidian comments wasn't recognized because the parser wasn't moved forward, causing the parser to detect the end as the beginning of a new comment.