### PR TITLE
fix: selection tabstop highlight

### DIFF
--- a/src/snippets/codemirror/tabstops_state_field.ts
+++ b/src/snippets/codemirror/tabstops_state_field.ts
@@ -64,7 +64,7 @@ export const tabstopsStateField = StateField.define<TabstopsState>({
 	},
 
 	provide: (field) => {
-		return EditorView.decorations.of(view => {
+		return EditorView.outerDecorations.of(view => {
 			// "Flatten" the array of DecorationSets to produce a single DecorationSet
 			const tabstopGroups = view.state.field(field).tabstopGroups;
 			const decos = [];


### PR DESCRIPTION
Because EditorView.decorations was used instead of EditorView.outerDecorations, the decorations were split up and the outlines overlap causing a slight visual disturbance.