### PR TITLE
feat: skip composite markers

### DIFF
--- a/src/features/run_snippets.ts
+++ b/src/features/run_snippets.ts
@@ -1,9 +1,9 @@
 import { EditorView } from "@codemirror/view";
-import { EditorState, SelectionRange } from "@codemirror/state";
+import { EditorState } from "@codemirror/state";
 import { getLatexSuiteConfig } from "src/snippets/codemirror/config";
 import { queueSnippet } from "src/snippets/codemirror/snippet_queue_state_field";
 import { expandSnippets } from "src/snippets/snippet_management";
-import { Context, getContextPlugin } from "src/utils/context";
+import { CMBound, Context, getContextPlugin } from "src/utils/context";
 import { autoEnlargeBrackets } from "./auto_enlarge_brackets";
 import { snippetDebugLevel } from "src/settings/settings";
 import { IncludedEnvironmentResult, Snippet, SnippetType } from "src/snippets/snippets";
@@ -25,7 +25,7 @@ export const runSnippets = (view: EditorView, snippetInfo: SnippetInfo, options:
 		let shouldAutoEnlargeBrackets = false;
 
 		for (const range of ctx.ranges) {
-			const result = runSnippetCursor(view, ctx, snippetInfo, range, options.debug);
+			const result = runSnippetCursor(view, ctx, snippetInfo, {from: range.from, to: range.to}, options.debug);
 
 			if (result.shouldAutoEnlargeBrackets) shouldAutoEnlargeBrackets = true;
 		}
@@ -54,12 +54,31 @@ const getSliceAroundCursor = (view: EditorView, to: number) => {
 	return {line, effectiveLineAfter};
 }
 
-const runSnippetCursor = (view: EditorView, ctx: Context, snippetInfo: SnippetInfo, range: SelectionRange, debug: snippetDebugLevel):{success: boolean; shouldAutoEnlargeBrackets: boolean} => {
+const runSnippetCursor = (view: EditorView, ctx: Context, snippetInfo: SnippetInfo, original_range: CMBound, debug: snippetDebugLevel):{success: boolean; shouldAutoEnlargeBrackets: boolean} => {
 
 	const settings = getLatexSuiteConfig(view);
-	const {from, to} = range;
-	const sel = view.state.sliceDoc(from, to);
-	const {line, effectiveLineAfter} = getSliceAroundCursor(view, to);
+	const original_sel = view.state.sliceDoc(original_range.from, original_range.to);
+	const {line, effectiveLineAfter} = getSliceAroundCursor(view, original_range.to);
+	const to = original_range.to;
+	const parsed_range = {from: original_range.from, to: original_range.to};
+	let parsedSel = original_sel;
+	// Remove indentations and callouts from selection as composite markers aren't really "part" of the text
+	// and make more sense to be removed from the selection.
+	if (original_range.from !== original_range.to) {
+		parsedSel = original_sel.replaceAll(/\n>*\s*/gm, "\n")
+		parsed_range.to = parsed_range.from + parsedSel.length;
+		const startLine = view.state.doc.lineAt(parsed_range.from);
+		if (startLine.from === parsed_range.from) {
+			const match = parsedSel.match(/^>*\s*/);
+			if (match) {
+				parsed_range.from += match[0].length;
+				parsedSel = parsedSel.replace(/^>*\s*/, "");
+			}
+		}	
+	}
+	const range = {original: original_range, parsed: parsed_range};
+	const sel = {original: original_sel, parsed: parsedSel};
+
 	const key = snippetInfo.key ?? "";
 	// If the key pressed wasn't a text character, continue
 	if (snippetInfo.key && snippetInfo.key.length !== 1) {

--- a/src/snippets/snippets.ts
+++ b/src/snippets/snippets.ts
@@ -1,15 +1,19 @@
-import { SelectionRange } from "@codemirror/state";
 import { Options } from "./options";
 import { BaseNode, ResultInsert, ArrayNode, SnippetTabstopOnlyNode, Options as InsertOptions } from "./luasnip_api/node";
 import * as v from "valibot";
 import { MacroArea } from "src/utils/default_text_areas";
-import { isMacroArgumentCount, StackOutput } from "src/utils/context";
+import { CMBound, isMacroArgumentCount, StackOutput } from "src/utils/context";
 import { EditorView } from "@codemirror/view";
 
 /**
  * in visual snippets, if the replacement is a string, this is the magic substring to indicate the selection.
  */
 export const VISUAL_SNIPPET_MAGIC_SELECTION_PLACEHOLDER = "${VISUAL}";
+/**
+ * Similar to ${VISUAL}, but refers to the original selection before any processing.
+ * can only be accessed through basenodes. Has the callouts and indentation preserved.
+ */
+const VISUAL_SNIPPET_MAGIC_SELECTION_PLACEHOLDER_ORIGINAL = "${VISUAL_ORIGINAL}";
 
 /**
  * there are 3 distinct types of snippets:
@@ -88,8 +92,14 @@ export enum IncludedEnvironmentResult {
 
 type ProccesArgs = {
 	effectiveLine: string;
-	range: SelectionRange;
-	sel: string;
+	range: {
+		original: CMBound;
+		parsed: CMBound;
+	};
+	sel: {
+		original: string;
+		parsed: string;
+	};
 	effectiveLineAfter: () => string;
 	view: EditorView
 }
@@ -190,26 +200,37 @@ export class VisualSnippet extends Snippet<"visual"> {
 	}
 
 	process({effectiveLine, range, sel, view}: ProccesArgs): ProcessSnippetResult {
-		const hasSelection = !!sel;
+		const hasSelection = !!sel.original;
 		// visual snippets only run when there is a selection
 		if (!hasSelection) { return null; }
 
 		// check whether the trigger text was typed
 		if (!(effectiveLine.endsWith(this.trigger))) { return null; }
 
-		const triggerPos = range.from;
+		let triggerPos = range.original.from;
 		let replacement: ResultInsert;
-		const captures = { match: [], groups: { [VISUAL_SNIPPET_MAGIC_SELECTION_PLACEHOLDER]: sel } };
+		const captures = {
+			match: [],
+			groups: {
+				[VISUAL_SNIPPET_MAGIC_SELECTION_PLACEHOLDER]: sel.parsed,
+				[VISUAL_SNIPPET_MAGIC_SELECTION_PLACEHOLDER_ORIGINAL]: sel.original,
+			},
+		};
 		const options: InsertOptions = { captures };
 		if (this.replacement instanceof ArrayNode) {
 			replacement = this.replacement.applyInsert(options);
 		} else {
-			const replacementTemp = convertOutputToNode(this.replacement(sel, {_view: view}))
+			const replacementTemp = convertOutputToNode(this.replacement(sel.parsed, {_view: view}))
 
 			// sanity check - if this.replacement was a function,
 			// we have no way to validate beforehand that it really does returns a valid output.
 			if (replacementTemp === null) { return null; }
 			replacement = replacementTemp.applyInsert(options);
+		}
+		if (replacement.tabstops.length === 0) {
+			const startDifference = range.parsed.from - range.original.from;
+			replacement.insert = sel.original.slice(0, startDifference) + replacement.insert;
+			replacement.tabstops = [{ from: 0, to: replacement.insert.length, index: [0] }];
 		}
 
 		return { triggerPos, replacement };
@@ -224,7 +245,7 @@ export class RegexSnippet extends Snippet<"regex"> {
 	}
 
 	process({effectiveLine, sel, effectiveLineAfter, view: _view}: ProccesArgs): ProcessSnippetResult {
-		const hasSelection = !!sel;
+		const hasSelection = !!sel.original;
 		// non-visual snippets only run when there is no selection
 		if (hasSelection) { return null; }
 
@@ -264,7 +285,7 @@ export class StringSnippet extends Snippet<"string"> {
 	}
 
 	process({effectiveLine, sel, effectiveLineAfter, view: _view}: ProccesArgs): ProcessSnippetResult {
-		const hasSelection = !!sel;
+		const hasSelection = !!sel.original;
 		// non-visual snippets only run when there is no selection
 		if (hasSelection) { return null; }
 


### PR DESCRIPTION
Fixes #513

In visual snippets, remove composite markers, e.g. callouts and indentation from the selection so when they are added back, they stay the same level.