### PR TITLE
fix: keep checking excludedMacros through nested environments

### DIFF
--- a/src/features/run_snippets.ts
+++ b/src/features/run_snippets.ts
@@ -90,7 +90,7 @@ const runSnippetCursor = (view: EditorView, ctx: Context, snippetInfo: SnippetIn
 	if (snippetInfo.key && snippetInfo.key.length !== 1) {
 		return {success: false, shouldAutoEnlargeBrackets: false};
 	}
-	const envNames = Array.from(ctx.getEnvNames())
+	const envNames = Array.from(ctx.getEnvNames(to))
 	const updatedLine = line + key;
 	for (let i=0; i < snippetInfo.snippets.length; i++) {
 		const snippet = snippetInfo.snippets[i];

--- a/src/snippets/snippets.ts
+++ b/src/snippets/snippets.ts
@@ -154,13 +154,12 @@ export abstract class Snippet<T extends SnippetType = SnippetType> {
 	isWithinExcludedScope(stack: StackOutput[]): boolean {
 		if (this.excludedEnvironments.length === 0 && this.excludedMacros.length === 0) return false;
 		for (const envName of stack) {
-			if (envName.kind === "environment" && this.excludedEnvironments.includes(envName.name)) {
-				return true;
+			if (envName.kind === "environment") {
+				if (this.excludedEnvironments.includes(envName.name)) return true;
+				// An environment does not end the enclosing macro's scope: \begin{align} inside \ce{}
+				// is still mhchem syntax, so keep walking outward to check excludedMacros.
+				continue;
 			} else if (envName.kind === "math") {
-				return false;
-				// environments always override the scope whereas macros can sometimes take scope from outer macro
-				// like \textcolor is math or text depending if its inside a \text macro or not.
-			} else if (envName.kind === "environment") {
 				return false;
 			} else if (isMacroArgumentCount(envName, this.excludedMacros)) {
 				return true;
@@ -171,9 +170,10 @@ export abstract class Snippet<T extends SnippetType = SnippetType> {
 	
 	isWithinIncludedScope(stack: StackOutput[]): IncludedEnvironmentResult {
 		if (this.includedMacros.length === 0) return IncludedEnvironmentResult.None;
-		if (stack.length === 0) return IncludedEnvironmentResult.NotIncluded
-		const firstName = stack[0]
-		if (firstName.kind === "math" || firstName.kind === "environment")
+		// Environments are skipped for the same reason as in isWithinExcludedScope, but only the
+		// innermost macro is considered: an included macro further out does not re-enable snippets.
+		const firstName = stack.find((envName) => envName.kind !== "environment");
+		if (firstName === undefined || firstName.kind === "math")
 			return IncludedEnvironmentResult.NotIncluded;
 		if (isMacroArgumentCount(firstName, this.includedMacros))
 			return IncludedEnvironmentResult.Included;

--- a/tests/context-snippets.ts
+++ b/tests/context-snippets.ts
@@ -15,6 +15,10 @@ export const names = [
 	["math-exclude-align", "m"],
 	["math-include-begin", "m"],
 	["math-include-color", "m"],
+	// See #629, environments generally override the allowed syntax thus the context changes
+	// Except the ones that do are generally not allowed inside macros that override their syntax thus environments are ignored
+	// as in most practical cases that makes the most sense. Also applies to math-exclude-pu.
+	["math-include-pu-align", "m"], 
 ] as const;
 
 const normal_name_options = [
@@ -70,7 +74,7 @@ export const transactionSpec: Spec[] = [
 		text: "$$\\pu{}$$",
 		pos: "$$\\pu{".length,
 		options: ["M", "m"],
-		names: ["display-math", "math", "math-exclude-align"],
+		names: ["display-math", "math", "math-exclude-align", "math-include-pu-align"],
 	},
 	{
 		text: "$$\\begin{align}a&=b\\\\c&=d\\end{align}$$",
@@ -90,7 +94,13 @@ export const transactionSpec: Spec[] = [
 		pos: "$$\\color{".length,
 		options: ["m"],
 		names: ["math-include-color"]
-	}
+	},
+	{
+		text: "$$ \\pu{ \\begin{align} &A -> B \\\\ &C -> D \\end{align} } $$",
+		pos: "$$ \\pu{ \\begin{align} &A -> B".length,
+		options: ["m", "M"],
+		names: ["math-include-pu-align", "display-math", "math"],
+	},
 ];
 
 let length = normal_name_options.length;
@@ -130,7 +140,16 @@ const snippets = (
 			name: "math-include-begin",
 			includedMacros: ["begin"],
 		},
-	] as const
+		{
+			trigger: (length++).toString(),
+			replacement: "",
+			options: "m",
+			name: "math-include-pu-align",
+			includedMacros: ["pu"],
+		},
+	] as const satisfies (Readonly<RawSnippet> & {
+		readonly name: (typeof names)[number]["0"];
+	})[]
 ).map(
 	(snippet) =>
 		({


### PR DESCRIPTION
Fixes #629

`isWithinExcludedScope` returned early on any environment that was not itself excluded, so a snippet's `excludedMacros` never applied once an environment sat between the cursor and the macro, e.g. `\ce{ \begin{align} A -> B \end{align} }` still expanded `->`. As discussed in #629, environments are now skipped instead, which matches what `Context.isWithinMacros` already does.

Changes in `src/snippets/snippets.ts`:

- `isWithinExcludedScope`: a non-excluded environment `continue`s the walk instead of returning `false`; `excludedEnvironments` and the math boundary behave as before.
- `isWithinIncludedScope`: skips environments too, but still only considers the innermost macro, so an included macro further out does not re-enable snippets.

`npm run lint` and `npm run build` pass. No test added, since the existing snippet tests run through the Obsidian integration harness; I will report a manual check with the default `->` and auto-subscript snippets inside `\ce{ \begin{align} ... }` on the issue.
