### PR TITLE
fix: mount settings editors in the Settings window's document

### DIFF
--- a/src/settings/settings_tab2.ts
+++ b/src/settings/settings_tab2.ts
@@ -814,15 +814,24 @@ class ConfirmationModal extends Modal {
 	}
 }
 
-function createCMEditor(content: string, extensions: Extension[], node: Element) {
+function createCMEditor(content: string, extensions: Extension[], node: HTMLElement) {
 	const view = new EditorView({
 		state: EditorState.create({ doc: content, extensions }),
 		parent: node,
-		// Obsidian 1.14 renders Settings in its own window. Without an explicit root, CodeMirror
-		// mounts its base theme into the main window's document, and the editor in the Settings
-		// window renders unstyled (gutter and content stacked as blocks, overflowing the box).
 		root: node.ownerDocument,
 	});
+
+	// Obsidian 1.14 renders Settings in its own window, and it builds the settings DOM in the
+	// main window before moving it there. CodeMirror mounts its base theme into the root it was
+	// given, so once the editor lands in a different document its styles are missing and the
+	// gutter and content render as plain blocks overflowing the box. Re-point the root whenever
+	// the editor is inserted or migrated into another window.
+	const syncRoot = () => {
+		const doc = view.dom.ownerDocument;
+		if (view.root !== doc) view.setRoot(doc);
+	};
+	node.onNodeInserted(syncRoot, true);
+	node.onWindowMigrated(syncRoot);
 
 	return view;
 }

--- a/src/settings/settings_tab2.ts
+++ b/src/settings/settings_tab2.ts
@@ -818,6 +818,10 @@ function createCMEditor(content: string, extensions: Extension[], node: Element)
 	const view = new EditorView({
 		state: EditorState.create({ doc: content, extensions }),
 		parent: node,
+		// Obsidian 1.14 renders Settings in its own window. Without an explicit root, CodeMirror
+		// mounts its base theme into the main window's document, and the editor in the Settings
+		// window renders unstyled (gutter and content stacked as blocks, overflowing the box).
+		root: node.ownerDocument,
 	});
 
 	return view;

--- a/src/settings/settings_tab2.ts
+++ b/src/settings/settings_tab2.ts
@@ -818,7 +818,7 @@ function createCMEditor(content: string, extensions: Extension[], node: HTMLElem
 	const view = new EditorView({
 		state: EditorState.create({ doc: content, extensions }),
 		parent: node,
-		root: node.ownerDocument,
+		root: activeDocument,
 	});
 
 	// Obsidian 1.14 renders Settings in its own window, and it builds the settings DOM in the
@@ -830,8 +830,14 @@ function createCMEditor(content: string, extensions: Extension[], node: HTMLElem
 		const doc = view.dom.ownerDocument;
 		if (view.root !== doc) view.setRoot(doc);
 	};
-	node.onNodeInserted(syncRoot, true);
-	node.onWindowMigrated(syncRoot);
+	const nodeDestroy = node.onNodeInserted(syncRoot, true);
+	const windowDestroy = node.onWindowMigrated(syncRoot);
+	const originalDestroy = view.destroy.bind(view);
+	view.destroy = () => {
+		nodeDestroy();
+		windowDestroy();
+		originalDestroy();
+	}
 
 	return view;
 }

--- a/src/settings/settings_tab2.ts
+++ b/src/settings/settings_tab2.ts
@@ -818,26 +818,10 @@ function createCMEditor(content: string, extensions: Extension[], node: HTMLElem
 	const view = new EditorView({
 		state: EditorState.create({ doc: content, extensions }),
 		parent: node,
+		// codemirror needs the root and thats different for popup windows.
+		// and the ownerDocument of node can be in a shadowRoot with 1.13+ api thus root needs to be set separately.
 		root: activeDocument,
 	});
-
-	// Obsidian 1.14 renders Settings in its own window, and it builds the settings DOM in the
-	// main window before moving it there. CodeMirror mounts its base theme into the root it was
-	// given, so once the editor lands in a different document its styles are missing and the
-	// gutter and content render as plain blocks overflowing the box. Re-point the root whenever
-	// the editor is inserted or migrated into another window.
-	const syncRoot = () => {
-		const doc = view.dom.ownerDocument;
-		if (view.root !== doc) view.setRoot(doc);
-	};
-	const nodeDestroy = node.onNodeInserted(syncRoot, true);
-	const windowDestroy = node.onWindowMigrated(syncRoot);
-	const originalDestroy = view.destroy.bind(view);
-	view.destroy = () => {
-		nodeDestroy();
-		windowDestroy();
-		originalDestroy();
-	}
 
 	return view;
 }


### PR DESCRIPTION
Fixes #640

Obsidian 1.14 renders Settings in its own window with its own `document`. `createCMEditor` constructed the `EditorView` with only `state` and `parent`, so CodeMirror defaulted its root to the main window's `document` and mounted the base theme (`.ͼ1 { display: flex !important; ... }`) there. The Settings window never got that stylesheet, so the Snippets and Snippet variables editors rendered as plain blocks with their content spilling out below the box.

Passing `root: node.ownerDocument` alone turned out not to be enough (first commit, tested with a BRAT build): Obsidian builds the settings DOM in the main window and migrates it into the Settings window afterwards, so `ownerDocument` is still the main document at construction time. The second commit keeps that and additionally re-points the root with `EditorView.setRoot` from Obsidian's `onNodeInserted` and `onWindowMigrated` hooks on the editor's parent element, so the styles follow the editor into whichever document it ends up in.

Verified in a live 1.14.1 Settings window that both hooks fire when a detached main-window element is appended into that window, that `view.root` stays the main document until `setRoot` is called, and that after `setRoot` the base theme is mounted there and the editor lays out as `display: flex` with a scrolling `.cm-scroller`. `npm run lint` and `npm run build` pass. On Obsidian versions that render Settings in the main window this is a no-op, since the root already matches.
